### PR TITLE
Debug chart display issue

### DIFF
--- a/src/stores/adverseCharts/adverseChartsStore.ts
+++ b/src/stores/adverseCharts/adverseChartsStore.ts
@@ -53,10 +53,12 @@ export const useAdverseChartsStore = defineStore('adverseCharts', () => {
             if (!counts[id]) counts[id] = { name, count: 0 }
             counts[id].count++
         })
-        return Object.entries(counts)
+        const result = Object.entries(counts)
             .map(([id, data]) => ({ id, name: data.name, count: data.count }))
             .filter((d) => !filters.value.excluded_departments.includes(d.id))
             .sort((a, b) => b.count - a.count)
+        
+        return result
     })
 
     // Данные для графика рисков
@@ -83,24 +85,27 @@ export const useAdverseChartsStore = defineStore('adverseCharts', () => {
     })
 
     // Chart.js формат
-    const doughnutChartData = computed(() => ({
-        labels: departmentsChartData.value.map((d) => d.name),
-        datasets: [
-            {
-                data: departmentsChartData.value.map((d) => d.count),
-                backgroundColor: [
-                    '#FF6384',
-                    '#36A2EB',
-                    '#FFCE56',
-                    '#4BC0C0',
-                    '#9966FF',
-                    '#FF9F40',
-                    '#C9CBCF',
-                ],
-                borderWidth: 1,
-            },
-        ],
-    }))
+    const doughnutChartData = computed(() => {
+        const chartData = {
+            labels: departmentsChartData.value.map((d) => d.name),
+            datasets: [
+                {
+                    data: departmentsChartData.value.map((d) => d.count),
+                    backgroundColor: [
+                        '#FF6384',
+                        '#36A2EB',
+                        '#FFCE56',
+                        '#4BC0C0',
+                        '#9966FF',
+                        '#FF9F40',
+                        '#C9CBCF',
+                    ],
+                    borderWidth: 1,
+                },
+            ],
+        }
+        return chartData
+    })
 
     const stackedBarChartData = computed(() => ({
         labels: risksChartData.value.map((r) => {


### PR DESCRIPTION
Refactor computed properties in `adverseChartsStore.ts` to use intermediate variables.

These changes were introduced during a debugging session to improve readability and facilitate inspection of intermediate data within computed properties.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8087f04-b280-4add-9deb-4649a169dccb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8087f04-b280-4add-9deb-4649a169dccb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

