### PR TITLE
Fix chart dataset visibility toggle error

### DIFF
--- a/src/components/dashboard/AdverseEventsChartsWidget.vue
+++ b/src/components/dashboard/AdverseEventsChartsWidget.vue
@@ -30,18 +30,26 @@ const doughnutOptions = computed(() => ({
                     legendItem.datasetIndex !== undefined
                         ? legendItem.datasetIndex
                         : legendItem.index
-                const chart = legend.chart
 
-                // Добавить эту проверку:
-                if (!chart) {
+                // Безопасные проверки
+                if (!legend?.chart?.data?.labels || index === undefined || index < 0) {
                     return
                 }
 
-                if (chart.isDatasetVisible(index)) {
-                    chart.hide(index)
-                } else {
-                    chart.show(index)
-                }
+                // Получаем название отделения
+                const departmentName = legend.chart.data.labels[index]
+                if (!departmentName) return
+
+                // Находим соответствующий ID отделения
+                const department = adverseCharts.departmentsChartData.find(d => d.name === departmentName)
+                if (!department) return
+
+                // Обновляем store - это автоматически обновит оба графика
+                adverseCharts.toggleDepartment(department.id)
+                
+                // Предотвращаем стандартное поведение Chart.js, так как мы управляем данными через store
+                event.preventDefault?.()
+                return false
             },
             labels: {
                 usePointStyle: true,


### PR DESCRIPTION
Refactor chart legend `onClick` handler to fix `_resolveAnimations` error and ensure reactive chart updates via the Pinia store.

The previous custom `onClick` handler manually toggled Chart.js dataset visibility while also updating the store, causing a conflict and the `TypeError: Cannot read properties of null (reading '_resolveAnimations')`. This change removes direct `chart.show()` and `chart.hide()` calls, instead relying entirely on the reactive store updates to manage dataset visibility, which correctly re-renders both charts.

---
<a href="https://cursor.com/background-agent?bcId=bc-451ebd3f-1418-42d3-914f-4357c5d185cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-451ebd3f-1418-42d3-914f-4357c5d185cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

