### PR TITLE
Investigate duplicate chat requests

### DIFF
--- a/src/layout/AppLayout.vue
+++ b/src/layout/AppLayout.vue
@@ -219,8 +219,9 @@ const layoutContainerName = computed(() => {
         <!-- Overlay-маска для меню -->
         <div class="layout-mask animate-fadein"></div>
 
-        <!-- Скользящий чат -->
+        <!-- Скользящий чат (не показываем на полной странице чата) -->
         <SlidingChat
+            v-if="router.currentRoute.value.name !== 'chat'"
             v-model:visible="isSlidingChatVisible"
             :initial-chat-id="slidingChatInitialChatId"
             :initial-user-id="slidingChatInitialUserId"

--- a/src/refactoring/modules/chat/components/SlidingChat.vue
+++ b/src/refactoring/modules/chat/components/SlidingChat.vue
@@ -298,7 +298,8 @@ watch(
                 } else if (newChatId) {
                     chatToOpen = chatStore.chats.find((c) => c.id === newChatId) || null
                     if (!chatToOpen) {
-                        await chatStore.fetchChats()
+                        // Попытаемся инициализировать чаты, если они еще не загружены
+                        await chatStore.initializeOnce()
                         chatToOpen = chatStore.chats.find((c) => c.id === newChatId) || null
                     }
                 }

--- a/src/refactoring/modules/chat/composables/useChatLogic.ts
+++ b/src/refactoring/modules/chat/composables/useChatLogic.ts
@@ -201,8 +201,8 @@ export function useChatLogic(options: ChatLogicOptions = {}) {
         }
 
         try {
-            // Загрузка чатов (ошибки обрабатываются внутри функции)
-            await chatStore.fetchChats()
+            // Загрузка чатов только один раз (предотвращение дублирования запросов)
+            await chatStore.initializeOnce()
 
             let chatToOpen: IChat | null = null
 

--- a/src/refactoring/modules/chat/stores/chatStore.ts
+++ b/src/refactoring/modules/chat/stores/chatStore.ts
@@ -55,6 +55,9 @@ export const useChatStore = defineStore('chatStore', {
         isSending: false,
         searchResults: null,
         isSearching: false,
+        // Флаг для предотвращения дублирования инициализации
+        isInitialized: false,
+        isInitializing: false,
     }),
     actions: {
         // Получает UUID текущего пользователя для подписки на центрифуго
@@ -130,6 +133,37 @@ export const useChatStore = defineStore('chatStore', {
                     }
                     break
             }
+        },
+
+        // Инициализирует чаты только один раз для предотвращения дублирования запросов
+        async initializeOnce(): Promise<void> {
+            // Если уже инициализировано или идет инициализация - выходим
+            if (this.isInitialized || this.isInitializing) {
+                return
+            }
+
+            this.isInitializing = true
+
+            try {
+                await this.fetchChats()
+                this.isInitialized = true
+            } catch (error) {
+                console.error('Ошибка при инициализации чатов:', error)
+                // Не устанавливаем isInitialized в true при ошибке,
+                // чтобы можно было повторить инициализацию
+            } finally {
+                this.isInitializing = false
+            }
+        },
+
+        // Сбрасывает состояние инициализации (например, при логауте)
+        resetInitialization(): void {
+            this.isInitialized = false
+            this.isInitializing = false
+            this.chats = []
+            this.currentChat = null
+            this.messages = []
+            this.searchResults = null
         },
 
         // Загружает список чатов. Управляет глобальным индикатором загрузки, логирует ошибки

--- a/src/refactoring/modules/chat/types/IChat.ts
+++ b/src/refactoring/modules/chat/types/IChat.ts
@@ -102,6 +102,9 @@ export interface IChatStoreState {
     isSending: boolean
     searchResults: ISearchResults | null
     isSearching: boolean
+    // Флаги для предотвращения дублирования инициализации
+    isInitialized: boolean
+    isInitializing: boolean
 }
 
 // Улучшенные типы для реакций


### PR DESCRIPTION
Prevent duplicate chat API requests by implementing a global initialization flag and conditionally rendering the sliding chat component.

The issue arose because both `ChatInterface.vue` (main chat page) and `SlidingChat.vue` (always mounted in `AppLayout.vue`) were calling `initialize()` in `onMounted` simultaneously, leading to redundant API calls for chat data, unread counts, messages, etc. This PR introduces a `initializeOnce()` method in the chat store and prevents `SlidingChat` from rendering when on the full chat page.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f2ded85-eadd-4bad-b19e-a01bdf7b89f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f2ded85-eadd-4bad-b19e-a01bdf7b89f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

