### PR TITLE
Fix chat message updates from centrifuge

### DIFF
--- a/CENTRIFUGE_FIX_SUMMARY.md
+++ b/CENTRIFUGE_FIX_SUMMARY.md
@@ -1,0 +1,128 @@
+# Исправление обработки сообщений Centrifuge
+
+## Проблема
+Сообщения из Centrifuge не обновлялись в чатах. Анализ показал несоответствие между структурой данных, получаемых от WebSocket, и логикой их обработки.
+
+## Структура данных от Centrifuge
+Согласно логам пользователя, данные приходят в следующем формате:
+```json
+{
+  "push": {
+    "channel": "chats:user#61fd72aa-9457-42b8-9098-7c0a676cad6e",
+    "pub": {
+      "data": {
+        "event_type": "new_message",
+        "data": {
+          "chat_id": 16,
+          "message": {
+            "id": 373,
+            "content": "12423423 42 ыф цу",
+            "is_read": false,
+            "is_edited": false,
+            "attachments": [],
+            "created_at": "2025-09-08T06:16:52.365056+05:00",
+            "created_by": {
+              "id": "365aa564-af67-4495-bf21-a5c58e97002e",
+              "first_name": "Михаил",
+              "last_name": "Стельмах"
+            },
+            "reactions": []
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Изменения
+
+### 1. Исправлена логика обработки в `handleCentrifugoMessage`
+**Файл:** `/workspace/src/refactoring/modules/chat/stores/chatStore.ts`
+
+**Было:**
+```typescript
+case 'new_message':
+    this.handleNewMessage(data.message || data.object || data, data.chat_id)
+    break
+```
+
+**Стало:**
+```typescript
+case 'new_message':
+    // Проверяем структуру данных из центрифуго
+    const messageData = data?.data?.message || data.message || data.object || data
+    const chatId = data?.data?.chat_id || data.chat_id
+    
+    console.log('📨 Обработка нового сообщения:', { messageData, chatId })
+    
+    if (messageData && chatId) {
+        this.handleNewMessage(messageData, chatId)
+    } else {
+        console.warn('⚠️ Некорректная структура данных для нового сообщения:', data)
+    }
+    break
+```
+
+### 2. Добавлено подробное логирование
+- В `centrifugeStore.ts` добавлено логирование получаемых публикаций
+- В `chatStore.ts` добавлено логирование обработки сообщений
+- Добавлен метод `debugTestCentrifugeMessage` для тестирования
+
+### 3. Улучшена обработка ошибок
+- Добавлены проверки на корректность структуры данных
+- Добавлены предупреждения при некорректных данных
+
+## Тестирование
+
+### 1. Автоматическое тестирование
+Запустите файл `debug-centrifuge-fix.js` в консоли браузера:
+```javascript
+// Скопируйте содержимое debug-centrifuge-fix.js в консоль браузера
+```
+
+### 2. Ручное тестирование через консоль
+```javascript
+// Получить store чата
+const chatStore = window.debugCentrifuge.getChatStore();
+
+// Протестировать с данными пользователя
+window.debugCentrifuge.testWithData({
+  event_type: "new_message",
+  data: {
+    chat_id: 16,
+    message: {
+      id: 999,
+      content: "Тестовое сообщение",
+      is_read: false,
+      is_edited: false,
+      attachments: [],
+      created_at: new Date().toISOString(),
+      created_by: {
+        id: "365aa564-af67-4495-bf21-a5c58e97002e",
+        first_name: "Михаил",
+        last_name: "Стельмах"
+      },
+      reactions: []
+    }
+  }
+});
+```
+
+### 3. Проверка в реальных условиях
+1. Откройте чат в приложении
+2. Отправьте сообщение из другого устройства/браузера
+3. Проверьте, что сообщение появляется без перезагрузки страницы
+4. Проверьте консоль на наличие логов с эмодзи (🔔, 📨, ✉️)
+
+## Ожидаемые результаты
+- Сообщения должны появляться в чате в реальном времени
+- В консоли должны появляться логи с соответствующими эмодзи
+- Счетчики непрочитанных сообщений должны обновляться
+- Звуки уведомлений должны воспроизводиться
+
+## Откат изменений
+Если что-то пойдет не так, можно откатить изменения:
+1. Удалить добавленное логирование
+2. Вернуть исходную логику в `handleCentrifugoMessage`
+3. Перезапустить приложение

--- a/debug-centrifuge-fix.js
+++ b/debug-centrifuge-fix.js
@@ -1,0 +1,104 @@
+// Отладочный скрипт для проверки исправления обработки сообщений Centrifuge
+// Запустите этот код в консоли браузера на странице с чатом
+
+console.log('🔧 Отладочный скрипт для проверки исправления Centrifuge');
+
+// Получаем доступ к store чата через Vue DevTools или глобальный объект
+function getChatStore() {
+    // Попробуем найти store через Vue DevTools
+    if (window.__VUE_DEVTOOLS_GLOBAL_HOOK__) {
+        const apps = window.__VUE_DEVTOOLS_GLOBAL_HOOK__.apps;
+        if (apps && apps.length > 0) {
+            const app = apps[0];
+            if (app && app.config && app.config.globalProperties) {
+                const $pinia = app.config.globalProperties.$pinia;
+                if ($pinia) {
+                    // Найдем store чата
+                    for (const store of Object.values($pinia._s)) {
+                        if (store.$id === 'chatStore') {
+                            return store;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    console.error('❌ Не удалось найти chatStore. Убедитесь, что приложение запущено и чат открыт.');
+    return null;
+}
+
+// Тестируем исправление
+function testCentrifugeFix() {
+    const chatStore = getChatStore();
+    if (!chatStore) return;
+
+    console.log('✅ ChatStore найден:', chatStore);
+    console.log('📊 Текущее состояние:', {
+        currentChat: chatStore.currentChat,
+        messagesCount: chatStore.messages.length,
+        chatsCount: chatStore.chats.length
+    });
+
+    // Тестируем с данными пользователя
+    const testData = {
+        event_type: "new_message",
+        data: {
+            chat_id: 16,
+            message: {
+                id: Math.floor(Math.random() * 10000) + 1000, // Уникальный ID
+                content: "Тестовое сообщение для проверки исправления " + new Date().toLocaleTimeString(),
+                is_read: false,
+                is_edited: false,
+                attachments: [],
+                created_at: new Date().toISOString(),
+                created_by: {
+                    id: "365aa564-af67-4495-bf21-a5c58e97002e",
+                    first_name: "Михаил",
+                    last_name: "Стельмах"
+                },
+                reactions: []
+            }
+        }
+    };
+
+    console.log('🧪 Тестируем с данными:', testData);
+    
+    if (typeof chatStore.debugTestCentrifugeMessage === 'function') {
+        chatStore.debugTestCentrifugeMessage(testData);
+    } else {
+        console.log('⚠️ Метод debugTestCentrifugeMessage не найден, вызываем handleCentrifugoMessage напрямую');
+        if (typeof chatStore.handleCentrifugoMessage === 'function') {
+            chatStore.handleCentrifugoMessage(testData);
+        } else {
+            console.error('❌ Метод handleCentrifugoMessage не найден');
+        }
+    }
+
+    // Проверяем результат через секунду
+    setTimeout(() => {
+        console.log('📈 Состояние после теста:', {
+            messagesCount: chatStore.messages.length,
+            lastMessage: chatStore.messages[chatStore.messages.length - 1]
+        });
+    }, 1000);
+}
+
+// Запускаем тест
+testCentrifugeFix();
+
+// Экспортируем функции для повторного использования
+window.debugCentrifuge = {
+    getChatStore,
+    testCentrifugeFix,
+    
+    // Прямой тест с пользовательскими данными
+    testWithData: (data) => {
+        const chatStore = getChatStore();
+        if (chatStore && typeof chatStore.handleCentrifugoMessage === 'function') {
+            chatStore.handleCentrifugoMessage(data);
+        }
+    }
+};
+
+console.log('✅ Отладочные функции доступны в window.debugCentrifuge');

--- a/src/refactoring/modules/centrifuge/stores/centrifugeStore.ts
+++ b/src/refactoring/modules/centrifuge/stores/centrifugeStore.ts
@@ -281,13 +281,24 @@ export const useCentrifugeStore = defineStore('centrifuge', {
                         offset: ctx.offset,
                         tags: ctx.tags,
                     })
+                    
+                    // Дополнительное логирование для отладки
+                    console.log('🔔 Centrifuge publication received:', {
+                        channel,
+                        fullContext: ctx,
+                        data: ctx.data
+                    })
+                    
                     const handler = this.handlers.get(channel)
                     if (handler) {
                         try {
                             handler(ctx.data)
                         } catch (e) {
                             this.logEvent('Handler error', e)
+                            console.error('❌ Centrifuge handler error:', e)
                         }
+                    } else {
+                        console.warn('⚠️ No handler found for channel:', channel)
                     }
                 })
 

--- a/src/refactoring/modules/chat/stores/chatStore.ts
+++ b/src/refactoring/modules/chat/stores/chatStore.ts
@@ -104,16 +104,29 @@ export const useChatStore = defineStore('chatStore', {
 
         // Обрабатывает сообщения из центрифуго
         handleCentrifugoMessage(data: any): void {
+            console.log('🔍 Обработка сообщения из центрифуго:', data)
+            
             const eventType = data?.event_type || data?.event || data?.type
 
             switch (eventType) {
                 case 'message':
                 case 'new_message':
-                    this.handleNewMessage(data.message || data.object || data, data.chat_id)
+                    // Проверяем структуру данных из центрифуго
+                    const messageData = data?.data?.message || data.message || data.object || data
+                    const chatId = data?.data?.chat_id || data.chat_id
+                    
+                    console.log('📨 Обработка нового сообщения:', { messageData, chatId })
+                    
+                    if (messageData && chatId) {
+                        this.handleNewMessage(messageData, chatId)
+                    } else {
+                        console.warn('⚠️ Некорректная структура данных для нового сообщения:', data)
+                    }
                     break
 
                 case 'chat_updated':
-                    this.handleChatUpdated(data.chat || data.object || data)
+                    const chatData = data?.data?.chat || data.chat || data.object || data
+                    this.handleChatUpdated(chatData)
                     break
 
                 case 'reaction_added':
@@ -127,6 +140,7 @@ export const useChatStore = defineStore('chatStore', {
                     break
 
                 default:
+                    console.log('🤷 Неизвестный тип события:', eventType, data)
                     // Fallback: если нет event_type, но есть id и content - считаем новым сообщением
                     if (data?.id && data?.content !== undefined) {
                         this.handleNewMessage(data, data.chat_id)
@@ -509,6 +523,14 @@ export const useChatStore = defineStore('chatStore', {
 
         // Обрабатывает новое сообщение из WebSocket
         handleNewMessage(message: IMessage, chatId: number): void {
+            console.log('✉️ Обработка нового сообщения:', {
+                messageId: message.id,
+                chatId,
+                currentChatId: this.currentChat?.id,
+                messageContent: message.content,
+                messageCreatedBy: message.created_by
+            })
+            
             const currentUserInfo = useCurrentUser(this.currentChat)
             const isFromCurrentUser = isMyMessage(
                 message,
@@ -517,13 +539,24 @@ export const useChatStore = defineStore('chatStore', {
             )
             const isCurrentChat = this.currentChat?.id === chatId
 
+            console.log('📊 Контекст обработки сообщения:', {
+                isCurrentChat,
+                isFromCurrentUser,
+                currentUserId: currentUserInfo.id.value,
+                messagesCountBefore: this.messages.length
+            })
+
             // Если это текущий чат - добавляем сообщение в список
             if (isCurrentChat) {
                 // Проверяем что сообщение еще не добавлено
                 const exists = this.messages.some((m) => m.id === message.id)
                 if (!exists) {
+                    console.log('➕ Добавляем новое сообщение в текущий чат')
                     this.messages.push(message)
                     this.messages.sort(compareMessagesAscending)
+                    console.log('📈 Сообщений после добавления:', this.messages.length)
+                } else {
+                    console.log('⚠️ Сообщение уже существует, пропускаем')
                 }
 
                 // Отмечаем как прочитанное
@@ -534,6 +567,7 @@ export const useChatStore = defineStore('chatStore', {
                 // Если это другой чат - увеличиваем счетчик непрочитанных
                 const chatIndex = this.chats.findIndex((c) => c.id === chatId)
                 if (chatIndex !== -1) {
+                    console.log('📈 Увеличиваем счетчик непрочитанных для чата', chatId)
                     const oldCount = this.chats[chatIndex].unread_count || 0
                     const updatedChats = [...this.chats]
                     updatedChats[chatIndex] = {
@@ -543,11 +577,14 @@ export const useChatStore = defineStore('chatStore', {
                         last_message: message,
                     }
                     this.chats = updatedChats
+                } else {
+                    console.warn('⚠️ Чат не найден в списке:', chatId)
                 }
             }
 
             // Воспроизводим звук для всех чужих сообщений (и в активном, и в неактивном чате)
             if (!isFromCurrentUser) {
+                console.log('🔊 Воспроизводим звук для чужого сообщения')
                 soundService.playNewMessageSound().catch(() => {
                     // Игнорируем ошибки воспроизведения звука
                 })
@@ -1047,6 +1084,38 @@ export const useChatStore = defineStore('chatStore', {
                 })
                 throw error
             }
+        },
+
+        // ============ ОТЛАДОЧНЫЕ МЕТОДЫ ============
+
+        // Метод для тестирования обработки сообщений из центрифуго
+        debugTestCentrifugeMessage(testData?: any): void {
+            console.log('🧪 Тестирование обработки сообщения из центрифуго')
+            
+            // Используем тестовые данные или данные из примера пользователя
+            const mockData = testData || {
+                event_type: "new_message",
+                data: {
+                    chat_id: 16,
+                    message: {
+                        id: 373,
+                        content: "12423423 42 ыф цу",
+                        is_read: false,
+                        is_edited: false,
+                        attachments: [],
+                        created_at: new Date().toISOString(),
+                        created_by: {
+                            id: "365aa564-af67-4495-bf21-a5c58e97002e",
+                            first_name: "Михаил",
+                            last_name: "Стельмах"
+                        },
+                        reactions: []
+                    }
+                }
+            }
+            
+            console.log('🧪 Тестовые данные:', mockData)
+            this.handleCentrifugoMessage(mockData)
         },
 
         // ============ ВСПОМОГАТЕЛЬНЫЕ МЕТОДЫ ============


### PR DESCRIPTION
Fixes chat messages not updating from Centrifuge by correcting the data extraction logic for nested message and chat ID fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-1d432549-a04d-44fe-af28-cc6c93a3741e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1d432549-a04d-44fe-af28-cc6c93a3741e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

