### PR TITLE
Fix chat reaction display and delete method

### DIFF
--- a/src/refactoring/modules/chat/components/MessageItem.vue
+++ b/src/refactoring/modules/chat/components/MessageItem.vue
@@ -372,11 +372,14 @@ function selectReaction(r: IReactionType) {
         avatar: null,
     }
 
+    // Сохраняем предыдущее значение реакции ДО изменения оптимистичного состояния
+    const prevReactionId = reactions.myReactionId.value
+
     reactions.clearOptimisticForMe()
     reactions.addOptimisticReaction(r.id, r.name, r.icon, user)
 
     if (String(r.id) !== String(-1)) {
-        emit('change-reaction', props.message.id, r.id, reactions.myReactionId.value)
+        emit('change-reaction', props.message.id, r.id, prevReactionId)
     }
 }
 
@@ -433,8 +436,10 @@ function onMessageLeave() {
 
 function onTriggerClick() {
     if (reactions.hasMyReaction.value) {
+        // Сохраняем ID реакции ДО очистки оптимистичного состояния
+        const prevReactionId = reactions.myReactionId.value
         reactions.clearOptimisticForMe()
-        emit('remove-my-reaction', props.message.id, reactions.myReactionId.value)
+        emit('remove-my-reaction', props.message.id, prevReactionId)
         closePicker()
         showTrigger.value = false
         isHoverTrigger.value = false

--- a/src/refactoring/modules/chat/composables/useChatLogic.ts
+++ b/src/refactoring/modules/chat/composables/useChatLogic.ts
@@ -171,20 +171,14 @@ export function useChatLogic(options: ChatLogicOptions = {}) {
 
         console.log('🎭 Обрабатываем изменение реакции:', {messageId, reactionId, prevReactionId})
         
-        // Очищаем старые реакции только если они есть
+        // Если у пользователя уже есть реакция - используем эксклюзивную установку
         if (prevReactionId !== null) {
-            try {
-                console.log('🧹 Очищаем существующую реакцию:', prevReactionId)
-                await chatStore.clearMyReactions(messageId)
-            } catch {
-                // Игнорируем ошибки очистки
-                console.warn('⚠️ Не удалось очистить существующую реакцию')
-            }
+            console.log('🔄 У пользователя уже есть реакция, используем эксклюзивную установку')
+            await chatStore.setExclusiveReaction(messageId, reactionId)
         } else {
-            console.log('✨ У пользователя нет реакций, сразу добавляем новую')
+            console.log('✨ У пользователя нет реакций, просто добавляем новую')
+            await chatStore.addReaction(messageId, reactionId)
         }
-        
-        await chatStore.addReaction(messageId, reactionId)
     }
 
     const removeMyReaction = async (messageId: number, prevReactionId: number | null) => {


### PR DESCRIPTION
Fix incorrect chat reaction handling by ensuring `prevReactionId` is captured before optimistic updates and preventing unnecessary DELETE requests.

Previously, adding a reaction to a message with no existing reactions would incorrectly send a DELETE request before a POST. Additionally, `prevReactionId` was sometimes captured *after* optimistic state updates, leading to an incorrect value being sent to the backend. This PR ensures the correct sequence of API calls and accurate `prevReactionId` transmission.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef8012ba-f2e1-4d61-905d-c208ff70aa80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ef8012ba-f2e1-4d61-905d-c208ff70aa80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

