### PR TITLE
Fix chat message sender distinction

### DIFF
--- a/src/refactoring/modules/chat/components/FileAttachmentCard.vue
+++ b/src/refactoring/modules/chat/components/FileAttachmentCard.vue
@@ -30,9 +30,13 @@ defineProps<{ href: string; name: string; time: string; mine: boolean }>()
 .attachment-file-card.mine {
     background: #34d399;
     color: #0f172a;
+    box-shadow: 0 2px 8px rgba(52, 211, 153, 0.3);
 }
 .attachment-file-card.theirs {
-    background: var(--p-surface-100);
+    background: #f1f5f9;
+    color: #334155;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+    border: 1px solid rgba(0, 0, 0, 0.06);
 }
 .attachment-file-card .thumb {
     width: 56px;
@@ -63,5 +67,13 @@ defineProps<{ href: string; name: string; time: string; mine: boolean }>()
 .attachment-file-card .time-inline {
     font-size: 12px;
     opacity: 0.85;
+}
+
+/* Стили для темной темы */
+:root[class*='app-dark'] .attachment-file-card.theirs {
+    background: #374151;
+    color: #f3f4f6;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.1);
 }
 </style>

--- a/src/refactoring/modules/chat/composables/useCurrentUser.ts
+++ b/src/refactoring/modules/chat/composables/useCurrentUser.ts
@@ -2,7 +2,7 @@
  * Композабл для работы с текущим пользователем в контексте чата
  * Централизует логику определения пользователя, его ID и имени
  */
-import { computed, ComputedRef } from 'vue'
+import { computed, type ComputedRef } from 'vue'
 import { useUserStore } from '@/refactoring/modules/user/stores/userStore'
 import type { IChat, IChatMember, IUser, IMessage } from '@/refactoring/modules/chat/types/IChat'
 

--- a/src/refactoring/modules/chat/styles/MessageItem.scss
+++ b/src/refactoring/modules/chat/styles/MessageItem.scss
@@ -15,11 +15,11 @@
       background: #059669 !important; 
       border-radius: 16px 4px 16px 16px !important;
       color: white !important;
-      box-shadow: 0 2px 4px rgba(5, 150, 105, 0.2);
+      box-shadow: 0 2px 8px rgba(5, 150, 105, 0.3);
     }
     
     .time {
-      color: rgba(255, 255, 255, 0.8) !important;
+      color: rgba(255, 255, 255, 0.85) !important;
     }
   }
   
@@ -28,10 +28,15 @@
     margin-right: auto;
     
     .message-content {
-      background: var(--p-surface-100) !important;
+      background: #f1f5f9 !important;
       border-radius: 4px 16px 16px 16px !important;
-      color: var(--p-surface-600) !important;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+      color: #334155 !important;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      border: 1px solid rgba(0, 0, 0, 0.06);
+    }
+    
+    .time {
+      color: #64748b !important;
     }
   }
 
@@ -269,3 +274,34 @@
 :deep(.attachment-file-card .meta) { font-size: 12px; opacity: 0.9; }
 :deep(.attachment-file-card .open-link) { text-decoration: underline; }
 :deep(.attachment-file-card .time-inline) { font-size: 12px; opacity: 0.85; }
+
+// Стили для темной темы
+:root[class*='app-dark'] {
+  .message {
+    &--mine {
+      .message-content {
+        background: #059669 !important; 
+        color: white !important;
+        box-shadow: 0 2px 8px rgba(5, 150, 105, 0.4);
+      }
+      
+      .time {
+        color: rgba(255, 255, 255, 0.85) !important;
+      }
+    }
+    
+    &--theirs {
+      .message-content {
+        background: #374151 !important;
+        border-radius: 4px 16px 16px 16px !important;
+        color: #f3f4f6 !important;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+      }
+      
+      .time {
+        color: #9ca3af !important;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Improve chat message and attachment styling to clearly differentiate between 'mine' and 'theirs' messages, including dark theme support.

Previously, the styling for chat messages and file attachments lacked sufficient visual contrast and dark theme considerations, making it difficult to differentiate between messages sent by the user and those received from others. This PR introduces distinct background colors, text colors, shadows, and borders for both light and dark themes to restore clear visual separation.

---
<a href="https://cursor.com/background-agent?bcId=bc-78884cbd-c12a-4d48-9cef-9242cf5f9cbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78884cbd-c12a-4d48-9cef-9242cf5f9cbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

