### PR TITLE
Fix return outside function in chat sidebar

### DIFF
--- a/src/refactoring/modules/chat/components/ChatSidebar.vue
+++ b/src/refactoring/modules/chat/components/ChatSidebar.vue
@@ -242,8 +242,6 @@ const publicChats = computed(() => {
         return typeMatch && isNotMember && isPublic
     })
 
-    })
-
     return result
 })
 


### PR DESCRIPTION
Remove an orphaned closing brace in `publicChats` computed property to fix compilation errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-d35bbdfc-9b22-4995-a7a6-67ede5acf650">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d35bbdfc-9b22-4995-a7a6-67ede5acf650">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

