### PR TITLE
Исправить отображение инициалов в реакциях чата

### DIFF
--- a/src/refactoring/modules/chat/components/MessageReactionsBar.vue
+++ b/src/refactoring/modules/chat/components/MessageReactionsBar.vue
@@ -40,11 +40,30 @@ const withBase = (path: string | null | undefined) => {
 }
 
 function getInitials(name: string): string {
-    const parts = String(name || '')
-        .trim()
-        .split(/\s+/)
-    if (parts.length === 0) return ''
-    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+    const trimmed = String(name || '').trim()
+    if (!trimmed) return '??'
+    
+    const parts = trimmed.split(/\s+/)
+    
+    // Если это fallback формат "User 123" или "User Unknown"
+    if (parts.length === 2 && parts[0] === 'User') {
+        const userId = parts[1]
+        // Если второй части - это число (ID), используем первые 2 цифры
+        if (/^\d+$/.test(userId)) {
+            return userId.slice(0, 2).padStart(2, '0')
+        }
+        // Если это "Unknown", используем специальные символы
+        if (userId === 'Unknown') {
+            return '??'
+        }
+        // Иначе используем первые 2 символа
+        return userId.slice(0, 2).toUpperCase()
+    }
+    
+    if (parts.length === 1) {
+        const word = parts[0]
+        return word.length === 1 ? word.toUpperCase() + '·' : word.slice(0, 2).toUpperCase()
+    }
     
     // Для имен пользователей берем инициалы в правильном порядке: Имя + Фамилия
     const firstName = parts[0]

--- a/src/refactoring/modules/chat/composables/useReactions.ts
+++ b/src/refactoring/modules/chat/composables/useReactions.ts
@@ -50,7 +50,7 @@ export function useReactions(
 
             const userEntry: ReactionUser = {
                 id: String(user?.user ?? user?.id ?? user?.user_id ?? Math.random()),
-                name: String(user?.user_name ?? user?.full_name ?? user?.name ?? 'Неизвестно'),
+                name: String(user?.user_name ?? user?.full_name ?? user?.name ?? `User ${user?.user ?? user?.id ?? user?.user_id ?? 'Unknown'}`),
                 avatar: user?.avatar || user?.icon || user?.photo || null,
             }
 
@@ -245,8 +245,8 @@ function processArrayFormat(array: any[], addUserToGroup: Function, chatMembers?
                 id: userId,
                 user: userId,
                 user_id: userId,
-                name: chatMember?.user_name || 'Пользователь',
-                user_name: chatMember?.user_name || 'Пользователь'
+                name: chatMember?.user_name || `User ${userId}`,
+                user_name: chatMember?.user_name || `User ${userId}`
             }
             usersSources.push(userObj)
         }


### PR DESCRIPTION
Improve display of user initials in chat reactions when no avatar is available to provide unique identifiers instead of generic 'ПО'.

The previous implementation used a fallback string 'Пользователь' (User) when user data was missing, which resulted in all such users displaying 'ПО' as initials. This made it impossible to distinguish between different users who reacted. The fix introduces a more specific fallback format like 'User {userId}' and updates the initial generation logic to extract the first two digits of the ID or '??' for truly unknown users, ensuring better clarity and distinction.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3349b3f-463c-4f07-85a0-1ada03f2afdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3349b3f-463c-4f07-85a0-1ada03f2afdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

