### PR TITLE
Display user initials or avatars for reactions

### DIFF
--- a/src/refactoring/modules/chat/composables/useChatLogic.ts
+++ b/src/refactoring/modules/chat/composables/useChatLogic.ts
@@ -1,6 +1,7 @@
 import { computed, onMounted, onUnmounted, ref, watch, shallowRef } from 'vue'
 import { useChatStore } from '@/refactoring/modules/chat/stores/chatStore'
 import { useCurrentUser } from '@/refactoring/modules/chat/composables/useCurrentUser'
+import { useApiStore } from '@/refactoring/modules/apiStore/stores/apiStore'
 import { toApiDate, formatDateOnly } from '@/refactoring/utils/formatters'
 
 import type {
@@ -33,6 +34,7 @@ interface MessageGroup {
 export function useChatLogic(options: ChatLogicOptions = {}) {
     const chatStore = useChatStore()
     const currentUser = useCurrentUser(chatStore.currentChat)
+    const apiStore = useApiStore()
 
     // Состояние компонента
     const messagesContainer = shallowRef<HTMLElement | null>(null)
@@ -198,6 +200,15 @@ export function useChatLogic(options: ChatLogicOptions = {}) {
         try {
             // Загрузка чатов только один раз (предотвращение дублирования запросов)
             await chatStore.initializeOnce()
+            
+            // Загружаем сотрудников для корректного отображения реакций
+            if (apiStore.employees.length === 0) {
+                try {
+                    await apiStore.fetchAllEmployees()
+                } catch (error) {
+                    console.warn('Не удалось загрузить данные сотрудников для чата:', error)
+                }
+            }
 
             let chatToOpen: IChat | null = null
 
@@ -209,13 +220,13 @@ export function useChatLogic(options: ChatLogicOptions = {}) {
                     chatToOpen = await chatStore.findOrCreateDirectChat(options.initialUserId)
                 } else if (options.initialChatId) {
                     // Ищем чат по ID в загруженном списке
-                    chatToOpen = chatStore.chats.find((c) => c.id === options.initialChatId) || null
+                    chatToOpen = chatStore.chats.find((c: IChat) => c.id === options.initialChatId) || null
                 } else {
                     // Попытка восстановить последний выбранный чат из localStorage
                     try {
                         const savedId = Number(localStorage.getItem('selectedChatId') || '')
                         if (savedId && !Number.isNaN(savedId)) {
-                            chatToOpen = chatStore.chats.find((c) => c.id === savedId) || null
+                            chatToOpen = chatStore.chats.find((c: IChat) => c.id === savedId) || null
                         }
                     } catch (e) {
                         // Игнорируем ошибки localStorage

--- a/src/refactoring/modules/chat/composables/useReactions.ts
+++ b/src/refactoring/modules/chat/composables/useReactions.ts
@@ -3,6 +3,8 @@
  * Выносит сложную логику реакций из MessageItem
  */
 import { computed, ref } from 'vue'
+import { useApiStore } from '@/refactoring/modules/apiStore/stores/apiStore'
+import type { IEmployee } from '@/refactoring/modules/apiStore/types/employees/IEmployee'
 import type {
     IMessage,
     IReactionType,
@@ -20,6 +22,29 @@ type ReactionLike = {
 const pickUserId = (r: ReactionLike): string | undefined => {
     const v = r?.user?.id ?? r?.user?.user ?? r?.user?.user_id ?? r?.id ?? r?.user_id
     return v == null ? undefined : String(v)
+}
+
+/**
+ * Получает информацию о пользователе из apiStore
+ * @param userId ID пользователя
+ * @returns Объект с именем и аватаркой пользователя
+ */
+function getUserInfo(userId: string): { name: string; avatar: string | null } {
+    const apiStore = useApiStore()
+    const employee = apiStore.employees.find((emp: IEmployee) => emp.id === userId)
+    
+    if (employee) {
+        const fullName = `${employee.first_name} ${employee.last_name}`.trim()
+        return {
+            name: fullName || `${employee.first_name || ''} ${employee.last_name || ''}`.trim() || `User ${userId}`,
+            avatar: null // В типе IEmployee нет поля avatar, но можно добавить позже
+        }
+    }
+    
+    return {
+        name: `User ${userId}`,
+        avatar: null
+    }
 }
 
 export function useReactions(
@@ -48,10 +73,15 @@ export function useReactions(
             const key = String(id || name || icon || 'unknown')
             const emoji = getReactionEmoji({ id: 0, name, icon } as IReactionType)
 
+            const userId = String(user?.user ?? user?.id ?? user?.user_id ?? Math.random())
+            
+            // Получаем информацию о пользователе из apiStore
+            const userInfo = getUserInfo(userId)
+            
             const userEntry: ReactionUser = {
-                id: String(user?.user ?? user?.id ?? user?.user_id ?? Math.random()),
-                name: String(user?.user_name ?? user?.full_name ?? user?.name ?? `User ${user?.user ?? user?.id ?? user?.user_id ?? 'Unknown'}`),
-                avatar: user?.avatar || user?.icon || user?.photo || null,
+                id: userId,
+                name: user?.user_name ?? user?.full_name ?? user?.name ?? userInfo.name,
+                avatar: user?.avatar || user?.icon || user?.photo || userInfo.avatar,
             }
 
             const existing = groups.get(key)
@@ -240,13 +270,17 @@ function processArrayFormat(array: any[], addUserToGroup: Function, chatMembers?
                 m.user === userId || m.user_uuid === userId
             )
             
+            // Получаем информацию о пользователе из apiStore
+            const userInfo = getUserInfo(userId)
+            
             // Создаем объект пользователя из user_id
             const userObj = {
                 id: userId,
                 user: userId,
                 user_id: userId,
-                name: chatMember?.user_name || `User ${userId}`,
-                user_name: chatMember?.user_name || `User ${userId}`
+                name: chatMember?.user_name || userInfo.name,
+                user_name: chatMember?.user_name || userInfo.name,
+                avatar: userInfo.avatar
             }
             usersSources.push(userObj)
         }


### PR DESCRIPTION
Display real user initials/avatars for chat reactions by utilizing `apiStore` employee data.

Previously, reactions showed user IDs as initials (`User {userId}`) instead of actual user names or avatars. This PR integrates the existing `apiStore.employees` data to show proper user names and their initials, and ensures employee data is loaded during chat initialization for correct display.

---
<a href="https://cursor.com/background-agent?bcId=bc-4096cc0c-c9e5-4747-b87f-e6293526ece0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4096cc0c-c9e5-4747-b87f-e6293526ece0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

