### PR TITLE
Fix reaction display for other users

### DIFF
--- a/REACTION_SYNC_FIX_FINAL.md
+++ b/REACTION_SYNC_FIX_FINAL.md
@@ -1,0 +1,98 @@
+# Исправление синхронизации реакций между пользователями
+
+## Проблема
+Реакции не синхронизировались между пользователями из-за отсутствия `user_id` в WebSocket сообщениях о реакциях.
+
+## Анализ
+1. **WebSocket данные**: В сообщениях о реакциях отсутствует поле `user_id`:
+   ```json
+   {
+     "event_type": "new_reaction",
+     "data": {
+       "chat_id": 16,
+       "message_id": 382,
+       "reaction_type_id": 3
+       // ❌ НЕТ user_id
+     }
+   }
+   ```
+
+2. **Локальное обновление**: Без `user_id` невозможно определить, какой пользователь добавил/удалил реакцию, что нарушает эксклюзивность реакций.
+
+## Решение
+Реализовано клиентское решение с автоматической перезагрузкой сообщений при отсутствии `user_id`:
+
+### Изменения в `chatStore.ts`
+
+1. **Добавлен debounced reload**:
+   ```typescript
+   // Debounce для перезагрузки сообщений при реакциях
+   reactionReloadTimeout: number | null
+
+   debouncedReloadMessages(chatId: number): void {
+       if (this.reactionReloadTimeout) {
+           clearTimeout(this.reactionReloadTimeout)
+       }
+       
+       this.reactionReloadTimeout = window.setTimeout(() => {
+           this.fetchMessages(chatId).catch((error) => {
+               console.error('Ошибка при обновлении сообщений после реакции:', error)
+           })
+           this.reactionReloadTimeout = null
+       }, 300)
+   }
+   ```
+
+2. **Улучшена обработка реакций**:
+   ```typescript
+   handleReactionUpdate(data: any): void {
+       // ... извлечение данных ...
+       
+       if (this.currentChat && chatId === this.currentChat.id) {
+           // ✅ Если нет userId - перезагружаем с сервера
+           if (!userId) {
+               console.log('🔄 Отсутствует userId в WebSocket данных, перезагружаем сообщения')
+               this.debouncedReloadMessages(this.currentChat.id)
+               return
+           }
+           
+           // Локальное обновление только если есть userId
+           const success = this.updateMessageReactionLocally(messageId, reactionTypeId, userId, eventType)
+           // ...
+       }
+   }
+   ```
+
+### Изменения в `centrifugeStore.ts`
+
+Добавлено расширенное логирование для отладки:
+```typescript
+if (eventType && eventType.includes('reaction')) {
+    const userId = reactionData?.user_id || reactionData?.user || ctx.data?.user_id || ctx.data?.user
+    
+    console.log('🎭 Centrifuge reaction event received:', {
+        // ... данные ...
+        hasUserId: !!userId,
+    })
+    
+    // ⚠️ Предупреждение если userId отсутствует
+    if (!userId) {
+        console.warn('⚠️ WebSocket реакция без userId - потребуется перезагрузка сообщений')
+    }
+}
+```
+
+## Результат
+- ✅ Реакции теперь корректно синхронизируются между всеми пользователями
+- ✅ Debounce предотвращает избыточные запросы к серверу
+- ✅ Улучшенное логирование для отладки
+- ✅ Graceful fallback при отсутствии `user_id` в WebSocket
+
+## Альтернативное решение
+Для полного решения проблемы рекомендуется **серверное исправление**: добавить `user_id` в WebSocket сообщения о реакциях. Это позволит использовать более эффективное локальное обновление вместо перезагрузки сообщений.
+
+## Тестирование
+1. Откройте чат в двух браузерах под разными пользователями
+2. Поставьте реакцию в одном браузере
+3. Убедитесь, что реакция появилась во втором браузере
+4. Проверьте логи в консоли для подтверждения срабатывания механизма

--- a/src/refactoring/modules/centrifuge/stores/centrifugeStore.ts
+++ b/src/refactoring/modules/centrifuge/stores/centrifugeStore.ts
@@ -285,15 +285,28 @@ export const useCentrifugeStore = defineStore('centrifuge', {
                     // Дополнительное логирование для отладки реакций
                     const eventType = ctx.data?.event_type || ctx.data?.event || ctx.data?.type
                     if (eventType && eventType.includes('reaction')) {
+                        const reactionData = ctx.data?.data || ctx.data
+                        const userId = reactionData?.user_id || reactionData?.user || ctx.data?.user_id || ctx.data?.user
+                        
                         console.log('🎭 Centrifuge reaction event received:', {
                             channel,
                             eventType,
-                            chatId: ctx.data?.data?.chat_id || ctx.data?.chat_id,
-                            messageId: ctx.data?.data?.message_id || ctx.data?.message_id,
-                            reactionTypeId: ctx.data?.data?.reaction_type_id || ctx.data?.reaction_type_id,
-                            userId: ctx.data?.data?.user_id || ctx.data?.user_id,
+                            chatId: reactionData?.chat_id || ctx.data?.chat_id,
+                            messageId: reactionData?.message_id || ctx.data?.message_id,
+                            reactionTypeId: reactionData?.reaction_type_id || ctx.data?.reaction_type_id,
+                            userId,
+                            hasUserId: !!userId,
                             fullData: ctx.data
                         })
+                        
+                        // Предупреждение если userId отсутствует
+                        if (!userId) {
+                            console.warn('⚠️ WebSocket реакция без userId - потребуется перезагрузка сообщений:', {
+                                eventType,
+                                chatId: reactionData?.chat_id || ctx.data?.chat_id,
+                                messageId: reactionData?.message_id || ctx.data?.message_id,
+                            })
+                        }
                     } else {
                         console.log('🔔 Centrifuge publication received:', {
                             channel,

--- a/src/refactoring/modules/chat/stores/chatStore.ts
+++ b/src/refactoring/modules/chat/stores/chatStore.ts
@@ -58,6 +58,8 @@ export const useChatStore = defineStore('chatStore', {
         // Флаг для предотвращения дублирования инициализации
         isInitialized: false,
         isInitializing: false,
+        // Debounce для перезагрузки сообщений при реакциях
+        reactionReloadTimeout: null as number | null,
     }),
     actions: {
         // Получает UUID текущего пользователя для подписки на центрифуго
@@ -163,6 +165,12 @@ export const useChatStore = defineStore('chatStore', {
             this.currentChat = null
             this.messages = []
             this.searchResults = null
+            
+            // Очищаем таймер перезагрузки реакций
+            if (this.reactionReloadTimeout) {
+                clearTimeout(this.reactionReloadTimeout)
+                this.reactionReloadTimeout = null
+            }
         },
 
         // Загружает список чатов. Управляет глобальным индикатором загрузки, логирует ошибки
@@ -577,8 +585,17 @@ export const useChatStore = defineStore('chatStore', {
                 return
             }
             
-            // Если это текущий чат, обновляем локально
+            // Если это текущий чат
             if (this.currentChat && chatId === this.currentChat.id) {
+                // Если нет userId в WebSocket данных, перезагружаем сообщения с сервера
+                // Это гарантирует правильную синхронизацию реакций между пользователями
+                if (!userId) {
+                    console.log('🔄 Отсутствует userId в WebSocket данных, перезагружаем сообщения')
+                    this.debouncedReloadMessages(this.currentChat.id)
+                    return
+                }
+                
+                // Пытаемся обновить локально только если есть userId
                 const success = this.updateMessageReactionLocally(messageId, reactionTypeId, userId, eventType)
                 
                 if (success) {
@@ -588,9 +605,7 @@ export const useChatStore = defineStore('chatStore', {
                 } else {
                     // Если локальное обновление не удалось, перезагружаем сообщения
                     console.warn('⚠️ Локальное обновление реакции не удалось, перезагружаем сообщения')
-                    this.fetchMessages(this.currentChat.id).catch((error) => {
-                        console.error('Ошибка при обновлении сообщений после реакции:', error)
-                    })
+                    this.debouncedReloadMessages(this.currentChat.id)
                 }
             } else {
                 // Если это не текущий чат, обновляем информацию о последнем сообщении в списке чатов
@@ -601,6 +616,22 @@ export const useChatStore = defineStore('chatStore', {
                     // В большинстве случаев пользователь увидит обновления при открытии чата
                 }
             }
+        },
+
+        // Debounced перезагрузка сообщений для избежания слишком частых запросов
+        debouncedReloadMessages(chatId: number): void {
+            // Очищаем предыдущий таймер
+            if (this.reactionReloadTimeout) {
+                clearTimeout(this.reactionReloadTimeout)
+            }
+            
+            // Устанавливаем новый таймер на 300ms
+            this.reactionReloadTimeout = window.setTimeout(() => {
+                this.fetchMessages(chatId).catch((error) => {
+                    console.error('Ошибка при обновлении сообщений после реакции:', error)
+                })
+                this.reactionReloadTimeout = null
+            }, 300)
         },
 
         // Локальное обновление реакции в сообщении

--- a/src/refactoring/modules/chat/types/IChat.ts
+++ b/src/refactoring/modules/chat/types/IChat.ts
@@ -114,6 +114,8 @@ export interface IChatStoreState {
     // Флаги для предотвращения дублирования инициализации
     isInitialized: boolean
     isInitializing: boolean
+    // Debounce для перезагрузки сообщений при реакциях
+    reactionReloadTimeout: number | null
 }
 
 // Улучшенные типы для реакций


### PR DESCRIPTION
Fixes reaction synchronization between users by reloading messages when `user_id` is missing from WebSocket reaction events.

WebSocket push notifications for reactions (`new_reaction` event) lacked the `user_id` of the reacting user. This prevented accurate local updates and cross-user synchronization. The solution implements a client-side fallback: if `user_id` is absent from the WebSocket event, a debounced full message reload is triggered to ensure eventual consistency, complemented by enhanced logging.

---
<a href="https://cursor.com/background-agent?bcId=bc-c075981c-5fc3-4fe0-a415-6243db62b9e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c075981c-5fc3-4fe0-a415-6243db62b9e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

