### PR TITLE
Decline chat invitation

### DIFF
--- a/CHAT_INVITATIONS_FEATURE.md
+++ b/CHAT_INVITATIONS_FEATURE.md
@@ -53,7 +53,7 @@
 ### POST /api/chat/invite/{id}/accept/
 Принятие приглашения в чат.
 
-### DELETE /api/chat/invite/{id}/
+### DELETE /api/chat/invite/{id}/decline/
 Отклонение приглашения в чат.
 
 ## Изменения в коде
@@ -64,7 +64,7 @@
 
 - **`initializeOnce()`** - добавлен вызов `fetchInvitations()` после загрузки чатов
 - **`fetchInvitations()`** - теперь сохраняет приглашения в состояние store
-- **`declineInvitation()`** - исправлен API endpoint с `/decline/` на `/`
+- **`declineInvitation()`** - использует API endpoint `/decline/` для отклонения приглашения
 
 #### Новая функциональность:
 
@@ -137,7 +137,7 @@ Content-Type: application/json
 POST {{BASE_URL}}/api/chat/invite/1/accept/
 
 # Отклонить приглашение  
-DELETE {{BASE_URL}}/api/chat/invite/1/
+DELETE {{BASE_URL}}/api/chat/invite/1/decline/
 ```
 
 ## Особенности реализации

--- a/src/refactoring/modules/chat/stores/chatStore.ts
+++ b/src/refactoring/modules/chat/stores/chatStore.ts
@@ -1223,7 +1223,7 @@ export const useChatStore = defineStore('chatStore', {
         async declineInvitation(invitationId: number): Promise<void> {
             try {
                 // Используем правильный endpoint для отклонения приглашения
-                await axios.delete(`${BASE_URL}/api/chat/invite/${invitationId}/`)
+                await axios.delete(`${BASE_URL}/api/chat/invite/${invitationId}/decline/`)
 
                 // Удаляем приглашение из списка
                 this.invitations = this.invitations.filter(inv => inv.id !== invitationId)


### PR DESCRIPTION
Update the chat invitation decline endpoint to `DELETE /api/chat/invite/{id}/decline/` for semantic clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb43c607-0180-4163-9bd1-ac6be38bf719">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb43c607-0180-4163-9bd1-ac6be38bf719">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

