### PR TITLE
Update tab title with unread message count

### DIFF
--- a/src/refactoring/modules/chat/composables/useUnreadMessages.ts
+++ b/src/refactoring/modules/chat/composables/useUnreadMessages.ts
@@ -1,11 +1,11 @@
-import { ref, watchEffect, readonly } from 'vue'
+import { ref, watchEffect, readonly, computed } from 'vue'
 
 /**
  * Composable для управления непрочитанными сообщениями в заголовке страницы
  * 
  * Особенности:
  * - Отслеживает количество непрочитанных сообщений
- * - Обновляет заголовок страницы только когда вкладка неактивна
+ * - Обновляет заголовок страницы всегда когда есть непрочитанные сообщения
  * - Автоматически сбрасывает счетчик при активации вкладки
  * - Сохраняет оригинальный заголовок страницы
  */
@@ -27,11 +27,10 @@ export function useUnreadMessages() {
   // Подписываемся на изменение видимости вкладки
   document.addEventListener('visibilitychange', handleVisibilityChange)
 
-  // watchEffect автоматически отслеживает unreadCount и isTabActive
+  // watchEffect автоматически отслеживает unreadCount
   watchEffect(() => {
-    // Обновляем заголовок только если есть непрочитанные сообщения
-    // и вкладка неактивна
-    document.title = unreadCount.value > 0 && !isTabActive.value
+    // Обновляем заголовок всегда, когда есть непрочитанные сообщения
+    document.title = unreadCount.value > 0
       ? `(${unreadCount.value}) ${originalTitle}`
       : originalTitle
   })
@@ -47,6 +46,10 @@ export function useUnreadMessages() {
     unreadCount.value = 0
   }
 
+  const setUnreadCount = (count: number) => {
+    unreadCount.value = count
+  }
+
   const cleanup = () => {
     document.removeEventListener('visibilitychange', handleVisibilityChange)
     // Восстанавливаем оригинальный заголовок при очистке
@@ -57,6 +60,7 @@ export function useUnreadMessages() {
     unreadCount, 
     incrementUnread, 
     resetUnread, 
+    setUnreadCount,
     cleanup,
     isTabActive: readonly(isTabActive)
   }

--- a/src/refactoring/modules/chat/stores/chatStore.ts
+++ b/src/refactoring/modules/chat/stores/chatStore.ts
@@ -204,6 +204,9 @@ export const useChatStore = defineStore('chatStore', {
                 // Загружаем счетчики непрочитанных сообщений (с обработкой ошибок)
                 await this.fetchUnreadCounts()
 
+                // Обновляем счетчик в заголовке после загрузки чатов
+                this.updateTitleUnreadCount()
+
                 // Подписываемся на единый канал пользователя для получения уведомлений о всех чатах
                 this.subscribeToUserChannel()
             } catch (error) {
@@ -517,6 +520,14 @@ export const useChatStore = defineStore('chatStore', {
             }
         },
 
+        // Обновляет счетчик непрочитанных сообщений в заголовке страницы
+        updateTitleUnreadCount(): void {
+            const totalUnread = this.chats.reduce((total, chat) => total + (chat.unread_count || 0), 0)
+            
+            // Устанавливаем счетчик через специальный метод
+            globalUnreadMessages.setUnreadCount(totalUnread)
+        },
+
         // Обрабатывает новое сообщение из WebSocket
         handleNewMessage(message: IMessage, chatId: number): void {
             const currentUserInfo = useCurrentUser(this.currentChat)
@@ -553,14 +564,14 @@ export const useChatStore = defineStore('chatStore', {
                         last_message: message,
                     }
                     this.chats = updatedChats
+                    
+                    // Обновляем счетчик в заголовке после изменения счетчиков чатов
+                    this.updateTitleUnreadCount()
                 }
             }
 
-            // Увеличиваем счетчик в заголовке для чужих сообщений
-            // (только если вкладка неактивна - логика внутри composable)
+            // Для чужих сообщений воспроизводим звук
             if (!isFromCurrentUser) {
-                globalUnreadMessages.incrementUnread()
-                
                 // Воспроизводим звук для всех чужих сообщений (и в активном, и в неактивном чате)
                 soundService.playNewMessageSound().catch(() => {
                     // Игнорируем ошибки воспроизведения звука
@@ -787,6 +798,9 @@ export const useChatStore = defineStore('chatStore', {
                         ...(lastMessageId && { last_read_message_id: lastMessageId }),
                     }
                     this.chats = updatedChats
+                    
+                    // Обновляем счетчик в заголовке после изменения счетчиков чатов
+                    this.updateTitleUnreadCount()
                 }
 
                 // Если это текущий чат, обновляем флаги прочитанности сообщений
@@ -806,9 +820,6 @@ export const useChatStore = defineStore('chatStore', {
         async openChat(chat: IChat): Promise<void> {
             // Устанавливаем текущий чат сразу, чтобы UI не ломался
             this.currentChat = chat
-
-            // Сбрасываем счетчик непрочитанных сообщений в заголовке при открытии чата
-            globalUnreadMessages.resetUnread()
 
             try {
                 localStorage.setItem('selectedChatId', String(chat.id))
@@ -837,6 +848,9 @@ export const useChatStore = defineStore('chatStore', {
                 } catch (error) {
                     console.warn('Не удалось отметить чат как прочитанный:', error)
                 }
+            } else {
+                // Если нет сообщений, все равно отмечаем чат как прочитанный
+                await this.markChatAsRead(chat.id)
             }
         },
 


### PR DESCRIPTION
Always display the total unread message count in the browser tab title to improve visibility for users.

The previous implementation only updated the tab title with unread counts when the browser tab was inactive. This PR removes that condition, ensuring the count is always visible. It also refactors the logic to calculate and synchronize the *total* unread messages across all chats with the tab title, providing a more accurate and consistent user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-d18f8bac-c626-421a-b090-cb4c4aa1e85f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d18f8bac-c626-421a-b090-cb4c4aa1e85f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

