### PR TITLE
Handle document file validation errors

### DIFF
--- a/src/refactoring/modules/documents/stores/documentsStore.ts
+++ b/src/refactoring/modules/documents/stores/documentsStore.ts
@@ -262,8 +262,13 @@ export const useDocumentsStore = defineStore('documentsStore', {
         const formData = new FormData()
         formData.append('name', payload.name)
         if (payload.description) formData.append('description', payload.description)
-        if (payload.type_id) formData.append('type_id', payload.type_id.toString())
-        if (payload.parent_folder) formData.append('parent_folder', payload.parent_folder)
+        // Исправляем поля в соответствии с требованиями API
+        // Обязательное поле type - если не указан type_id, используем значение по умолчанию
+        formData.append('type', payload.type_id ? payload.type_id.toString() : '1')
+        // Добавляем обязательное поле number (можно использовать timestamp или другую логику)
+        formData.append('number', Date.now().toString())
+        // Исправляем название поля для папки - обязательное поле
+        formData.append('folder_path', payload.parent_folder || this.currentFolderId || '/')
         formData.append('file', payload.file)
         formData.append('visibility', payload.visibility)
 


### PR DESCRIPTION
Align document creation payload with API requirements to resolve validation errors for `type`, `number`, and `folder_path` fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a78193a-ed16-414e-ba0d-b5eff7b28d18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a78193a-ed16-414e-ba0d-b5eff7b28d18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

