### PR TITLE
Fix modal not closing after document deletion

### DIFF
--- a/src/refactoring/modules/documents/components/DocumentsInterface.vue
+++ b/src/refactoring/modules/documents/components/DocumentsInterface.vue
@@ -376,8 +376,15 @@ const confirmDeleteFolder = (folder: IDocumentFolder) => {
     acceptLabel: 'Удалить',
     rejectLabel: 'Отмена',
     acceptClass: 'p-button-danger',
-    accept: () => {
-      documentsStore.deleteFolder(folder.id!)
+    accept: async () => {
+      try {
+        await documentsStore.deleteFolder(folder.id!)
+        // Успешное удаление - модальное окно автоматически закроется
+      } catch (error) {
+        // В случае ошибки модальное окно также должно закрыться
+        // Ошибка уже обработана в documentsStore.deleteFolder
+        console.error('Error deleting folder:', error)
+      }
     }
   })
 }
@@ -390,8 +397,15 @@ const confirmDeleteDocument = (document: IDocument) => {
     acceptLabel: 'Удалить',
     rejectLabel: 'Отмена',
     acceptClass: 'p-button-danger',
-    accept: () => {
-      documentsStore.deleteDocument(document.id)
+    accept: async () => {
+      try {
+        await documentsStore.deleteDocument(document.id)
+        // Успешное удаление - модальное окно автоматически закроется
+      } catch (error) {
+        // В случае ошибки модальное окно также должно закрыться
+        // Ошибка уже обработана в documentsStore.deleteDocument
+        console.error('Error deleting document:', error)
+      }
     }
   })
 }


### PR DESCRIPTION
Make document/folder deletion confirmation modals close correctly by awaiting asynchronous operations.

The previous implementation used synchronous callbacks for `confirm.require()`, which didn't wait for the `deleteDocument` or `deleteFolder` promises to resolve. This caused the confirmation modal to remain open if the deletion operation was still pending or failed. By making the callbacks `async` and `await`ing the store calls, the modal now correctly closes after the operation completes.

---
<a href="https://cursor.com/background-agent?bcId=bc-32577fb6-e417-4bce-b4e7-d783ea6058e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-32577fb6-e417-4bce-b4e7-d783ea6058e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

