### PR TITLE
Debug modal closing after file deletion

### DIFF
--- a/src/refactoring/modules/documents/components/DocumentsInterface.vue
+++ b/src/refactoring/modules/documents/components/DocumentsInterface.vue
@@ -367,8 +367,13 @@ const openAddVersionDialog = (document: IDocument) => {
 }
 
 const confirmDeleteFolder = (folder: IDocumentFolder) => {
-  if (!folder.id) return
+  console.log(`🗂️ CONFIRM DELETE FOLDER: Starting confirmation for folder "${folder.name}" (id: ${folder.id})`)
+  if (!folder.id) {
+    console.warn(`⚠️ CONFIRM DELETE FOLDER: No folder ID, aborting deletion`)
+    return
+  }
   
+  console.log(`📋 CONFIRM DELETE FOLDER: Showing confirmation dialog for folder ${folder.id}`)
   confirm.require({
     message: `Вы уверены, что хотите удалить папку "${folder.name}"?`,
     header: 'Подтверждение удаления',
@@ -376,20 +381,35 @@ const confirmDeleteFolder = (folder: IDocumentFolder) => {
     acceptLabel: 'Удалить',
     rejectLabel: 'Отмена',
     acceptClass: 'p-button-danger',
-    accept: async () => {
-      try {
-        await documentsStore.deleteFolder(folder.id!)
-        // Папка успешно удалена, модальное окно закроется автоматически
-      } catch (error) {
-        // Ошибка уже обработана в documentsStore.deleteFolder
-        console.error('Error deleting folder:', error)
-        // Не пробрасываем ошибку дальше, чтобы модальное окно закрылось
-      }
+    accept: () => {
+      console.log(`✅ CONFIRM DELETE FOLDER: User confirmed deletion of folder ${folder.id}`)
+      console.log(`🚀 CONFIRM DELETE FOLDER: Calling documentsStore.deleteFolder(${folder.id})`)
+      
+      // ВАЖНО: Убираем async/await из accept функции, чтобы модалка закрылась сразу
+      // Вместо этого запускаем удаление асинхронно
+      documentsStore.deleteFolder(folder.id!)
+        .then(() => {
+          console.log(`✅ CONFIRM DELETE FOLDER: Successfully deleted folder ${folder.id}`)
+        })
+        .catch((error) => {
+          console.error(`❌ CONFIRM DELETE FOLDER: Error deleting folder ${folder.id}:`, error)
+        })
+        .finally(() => {
+          console.log(`🏁 CONFIRM DELETE FOLDER: Finished processing deletion for folder ${folder.id}`)
+        })
+      
+      console.log(`🔄 CONFIRM DELETE FOLDER: Accept function completed, modal should close now`)
+    },
+    reject: () => {
+      console.log(`❌ CONFIRM DELETE FOLDER: User cancelled deletion of folder ${folder.id}`)
     }
   })
 }
 
 const confirmDeleteDocument = (document: IDocument) => {
+  console.log(`🗑️ CONFIRM DELETE DOCUMENT: Starting confirmation for document "${document.name}" (id: ${document.id})`)
+  
+  console.log(`📋 CONFIRM DELETE DOCUMENT: Showing confirmation dialog for document ${document.id}`)
   confirm.require({
     message: `Вы уверены, что хотите удалить документ "${document.name}"?`,
     header: 'Подтверждение удаления',
@@ -397,15 +417,27 @@ const confirmDeleteDocument = (document: IDocument) => {
     acceptLabel: 'Удалить',
     rejectLabel: 'Отмена',
     acceptClass: 'p-button-danger',
-    accept: async () => {
-      try {
-        await documentsStore.deleteDocument(document.id)
-        // Документ успешно удален, модальное окно закроется автоматически
-      } catch (error) {
-        // Ошибка уже обработана в documentsStore.deleteDocument
-        console.error('Error deleting document:', error)
-        // Не пробрасываем ошибку дальше, чтобы модальное окно закрылось
-      }
+    accept: () => {
+      console.log(`✅ CONFIRM DELETE DOCUMENT: User confirmed deletion of document ${document.id}`)
+      console.log(`🚀 CONFIRM DELETE DOCUMENT: Calling documentsStore.deleteDocument(${document.id})`)
+      
+      // ВАЖНО: Убираем async/await из accept функции, чтобы модалка закрылась сразу
+      // Вместо этого запускаем удаление асинхронно
+      documentsStore.deleteDocument(document.id)
+        .then(() => {
+          console.log(`✅ CONFIRM DELETE DOCUMENT: Successfully deleted document ${document.id}`)
+        })
+        .catch((error) => {
+          console.error(`❌ CONFIRM DELETE DOCUMENT: Error deleting document ${document.id}:`, error)
+        })
+        .finally(() => {
+          console.log(`🏁 CONFIRM DELETE DOCUMENT: Finished processing deletion for document ${document.id}`)
+        })
+      
+      console.log(`🔄 CONFIRM DELETE DOCUMENT: Accept function completed, modal should close now`)
+    },
+    reject: () => {
+      console.log(`❌ CONFIRM DELETE DOCUMENT: User cancelled deletion of document ${document.id}`)
     }
   })
 }

--- a/src/refactoring/modules/documents/stores/documentsStore.ts
+++ b/src/refactoring/modules/documents/stores/documentsStore.ts
@@ -62,6 +62,7 @@ export const useDocumentsStore = defineStore('documentsStore', {
     },
 
     async fetchDocuments(payload: IListDocumentsPayload = {}): Promise<void> {
+      console.log(`📥 FETCH DOCUMENTS START: payload=`, payload)
       const feedback = useFeedbackStore()
       this.isLoading = true
       feedback.isGlobalLoading = true
@@ -148,8 +149,10 @@ export const useDocumentsStore = defineStore('documentsStore', {
         })
         throw error
       } finally {
+        console.log(`🏁 FETCH DOCUMENTS FINALLY: Setting loading to false`)
         this.isLoading = false
         feedback.isGlobalLoading = false
+        console.log(`✅ FETCH DOCUMENTS COMPLETE: items count=${this.currentItems.length}`)
       }
     },
 
@@ -342,15 +345,20 @@ export const useDocumentsStore = defineStore('documentsStore', {
     },
 
     async deleteDocument(id: number): Promise<void> {
+      console.log(`🗑️ DELETE DOCUMENT START: id=${id}`)
       const feedback = useFeedbackStore()
+      console.log(`⏳ DELETE DOCUMENT: Setting global loading to true`)
       feedback.isGlobalLoading = true
       
       try {
+        console.log(`🌐 DELETE DOCUMENT API CALL: sending DELETE to ${BASE_URL}/api/documents/document/${id}/`)
         const response = await axios.delete(`${BASE_URL}/api/documents/document/${id}/`)
+        console.log(`✅ DELETE DOCUMENT API RESPONSE: status=${response.status}, data=`, response.data)
         
         // Проверяем успешность удаления по статусу ответа
         // 204 No Content - стандартный успешный ответ для DELETE операций
         if (response.status === 204 || response.status === 200) {
+          console.log(`✅ DELETE DOCUMENT SUCCESS: Document ${id} deleted successfully`)
           useFeedbackStore().showToast({ 
             type: 'success', 
             title: 'Удалено', 
@@ -358,12 +366,16 @@ export const useDocumentsStore = defineStore('documentsStore', {
             time: 4000 
           })
 
+          console.log(`🔄 DELETE DOCUMENT: Refreshing documents list...`)
           // Обновляем список
           await this.fetchDocuments()
+          console.log(`✅ DELETE DOCUMENT: Documents list refreshed, new items count: ${this.currentItems.length}`)
         } else {
+          console.log(`❌ DELETE DOCUMENT UNEXPECTED STATUS: ${response.status}`)
           throw new Error(`Unexpected response status: ${response.status}`)
         }
       } catch (error) {
+        console.error(`❌ DELETE DOCUMENT ERROR: Failed to delete document ${id}:`, error)
         logger.error('documents_delete_error', { 
           file: 'documentsStore', 
           function: 'deleteDocument', 
@@ -377,20 +389,27 @@ export const useDocumentsStore = defineStore('documentsStore', {
         })
         throw error
       } finally {
+        console.log(`🏁 DELETE DOCUMENT FINALLY: Setting global loading to false for document ${id}`)
         feedback.isGlobalLoading = false
+        console.log(`✅ DELETE DOCUMENT FINALLY: Global loading set to false`)
       }
     },
 
     async deleteFolder(id: number): Promise<void> {
+      console.log(`🗂️ DELETE FOLDER START: id=${id}`)
       const feedback = useFeedbackStore()
+      console.log(`⏳ DELETE FOLDER: Setting global loading to true`)
       feedback.isGlobalLoading = true
       
       try {
+        console.log(`🌐 DELETE FOLDER API CALL: sending DELETE to ${BASE_URL}/api/documents/document-folder/${id}/`)
         const response = await axios.delete(`${BASE_URL}/api/documents/document-folder/${id}/`)
+        console.log(`✅ DELETE FOLDER API RESPONSE: status=${response.status}, data=`, response.data)
         
         // Проверяем успешность удаления по статусу ответа
         // 204 No Content - стандартный успешный ответ для DELETE операций
         if (response.status === 204 || response.status === 200) {
+          console.log(`✅ DELETE FOLDER SUCCESS: Folder ${id} deleted successfully`)
           useFeedbackStore().showToast({ 
             type: 'success', 
             title: 'Удалено', 
@@ -398,12 +417,16 @@ export const useDocumentsStore = defineStore('documentsStore', {
             time: 4000 
           })
 
+          console.log(`🔄 DELETE FOLDER: Refreshing documents list...`)
           // Обновляем список
           await this.fetchDocuments()
+          console.log(`✅ DELETE FOLDER: Documents list refreshed, new items count: ${this.currentItems.length}`)
         } else {
+          console.log(`❌ DELETE FOLDER UNEXPECTED STATUS: ${response.status}`)
           throw new Error(`Unexpected response status: ${response.status}`)
         }
       } catch (error) {
+        console.error(`❌ DELETE FOLDER ERROR: Failed to delete folder ${id}:`, error)
         logger.error('documents_deleteFolder_error', { 
           file: 'documentsStore', 
           function: 'deleteFolder', 
@@ -417,7 +440,9 @@ export const useDocumentsStore = defineStore('documentsStore', {
         })
         throw error
       } finally {
+        console.log(`🏁 DELETE FOLDER FINALLY: Setting global loading to false for folder ${id}`)
         feedback.isGlobalLoading = false
+        console.log(`✅ DELETE FOLDER FINALLY: Global loading set to false`)
       }
     },
 


### PR DESCRIPTION
Fixes modal not closing after document/folder deletion and adds extensive logging for debugging.

The `accept` callback in `confirm.require()` was `async`, which prevented PrimeVue's ConfirmDialog from automatically closing. The fix involves making the `accept` function synchronous and handling the asynchronous deletion with `.then()/.catch()/.finally()`. Detailed logs have been added to trace the deletion process.

---
<a href="https://cursor.com/background-agent?bcId=bc-363522c7-dd75-45fc-8c52-492f69d8f162">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-363522c7-dd75-45fc-8c52-492f69d8f162">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

