### PR TITLE
Delete document and refresh list

### DIFF
--- a/src/refactoring/modules/documents/components/DocumentsInterface.vue
+++ b/src/refactoring/modules/documents/components/DocumentsInterface.vue
@@ -381,20 +381,23 @@ const confirmDeleteFolder = (folder: IDocumentFolder) => {
     acceptLabel: 'Удалить',
     rejectLabel: 'Отмена',
     acceptClass: 'p-button-danger',
-    accept: async () => {
+    accept: () => {
       console.log(`✅ CONFIRM DELETE FOLDER: User confirmed deletion of folder ${folder.id}`)
       console.log(`🚀 CONFIRM DELETE FOLDER: Calling documentsStore.deleteFolder(${folder.id})`)
       
-      try {
-        await documentsStore.deleteFolder(folder.id!)
-        console.log(`✅ CONFIRM DELETE FOLDER: Successfully deleted folder ${folder.id}`)
-      } catch (error) {
-        console.error(`❌ CONFIRM DELETE FOLDER: Error deleting folder ${folder.id}:`, error)
-      } finally {
-        console.log(`🏁 CONFIRM DELETE FOLDER: Finished processing deletion for folder ${folder.id}`)
-      }
-      
-      console.log(`🔄 CONFIRM DELETE FOLDER: Accept function completed, modal should close now`)
+      return documentsStore.deleteFolder(folder.id!)
+        .then(() => {
+          console.log(`✅ CONFIRM DELETE FOLDER: Successfully deleted folder ${folder.id}`)
+          console.log(`🔄 CONFIRM DELETE FOLDER: Accept function completed, modal should close now`)
+        })
+        .catch((error) => {
+          console.error(`❌ CONFIRM DELETE FOLDER: Error deleting folder ${folder.id}:`, error)
+          // Повторно выбрасываем ошибку, чтобы модальное окно не закрылось при ошибке
+          throw error
+        })
+        .finally(() => {
+          console.log(`🏁 CONFIRM DELETE FOLDER: Finished processing deletion for folder ${folder.id}`)
+        })
     },
     reject: () => {
       console.log(`❌ CONFIRM DELETE FOLDER: User cancelled deletion of folder ${folder.id}`)
@@ -413,20 +416,23 @@ const confirmDeleteDocument = (document: IDocument) => {
     acceptLabel: 'Удалить',
     rejectLabel: 'Отмена',
     acceptClass: 'p-button-danger',
-    accept: async () => {
+    accept: () => {
       console.log(`✅ CONFIRM DELETE DOCUMENT: User confirmed deletion of document ${document.id}`)
       console.log(`🚀 CONFIRM DELETE DOCUMENT: Calling documentsStore.deleteDocument(${document.id})`)
       
-      try {
-        await documentsStore.deleteDocument(document.id)
-        console.log(`✅ CONFIRM DELETE DOCUMENT: Successfully deleted document ${document.id}`)
-      } catch (error) {
-        console.error(`❌ CONFIRM DELETE DOCUMENT: Error deleting document ${document.id}:`, error)
-      } finally {
-        console.log(`🏁 CONFIRM DELETE DOCUMENT: Finished processing deletion for document ${document.id}`)
-      }
-      
-      console.log(`🔄 CONFIRM DELETE DOCUMENT: Accept function completed, modal should close now`)
+      return documentsStore.deleteDocument(document.id)
+        .then(() => {
+          console.log(`✅ CONFIRM DELETE DOCUMENT: Successfully deleted document ${document.id}`)
+          console.log(`🔄 CONFIRM DELETE DOCUMENT: Accept function completed, modal should close now`)
+        })
+        .catch((error) => {
+          console.error(`❌ CONFIRM DELETE DOCUMENT: Error deleting document ${document.id}:`, error)
+          // Повторно выбрасываем ошибку, чтобы модальное окно не закрылось при ошибке
+          throw error
+        })
+        .finally(() => {
+          console.log(`🏁 CONFIRM DELETE DOCUMENT: Finished processing deletion for document ${document.id}`)
+        })
     },
     reject: () => {
       console.log(`❌ CONFIRM DELETE DOCUMENT: User cancelled deletion of document ${document.id}`)


### PR DESCRIPTION
Refactor `accept` callbacks in ConfirmDialog to return a Promise, ensuring the modal closes correctly after asynchronous operations.

Previously, the PrimeVue ConfirmDialog was not closing automatically after a successful asynchronous deletion because the `async/await` syntax within the `accept` function did not correctly signal the dialog to wait for the operation's completion. By returning the Promise directly from the `documentsStore` deletion methods, the dialog now correctly awaits the operation's resolution before closing, and remains open if an error occurs.

---
<a href="https://cursor.com/background-agent?bcId=bc-c449fab9-8595-4d0f-bb6d-16b3f50ac73a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c449fab9-8595-4d0f-bb6d-16b3f50ac73a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

