### PR TITLE
Fix document module type errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
                 "prettier": "^3.2.5",
                 "sass": "^1.55.0",
                 "tailwindcss": "^3.4.6",
-                "typescript": "^5.8.3",
+                "typescript": "^5.9.2",
                 "undici": "^7.10.0",
                 "undici-types": "^7.10.0",
                 "unplugin-vue-components": "^0.27.3",
@@ -1945,17 +1945,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.35.0.tgz",
-            "integrity": "sha512-ijItUYaiWuce0N1SoSMrEd0b6b6lYkYt99pqCPfybd+HKVXtEvYhICfLdwp42MhiI5mp0oq7PKEL+g1cNiz/Eg==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.0.tgz",
+            "integrity": "sha512-EGDAOGX+uwwekcS0iyxVDmRV9HX6FLSM5kzrAToLTsr9OWCIKG/y3lQheCq18yZ5Xh78rRKJiEpP0ZaCs4ryOQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.35.0",
-                "@typescript-eslint/type-utils": "8.35.0",
-                "@typescript-eslint/utils": "8.35.0",
-                "@typescript-eslint/visitor-keys": "8.35.0",
+                "@typescript-eslint/scope-manager": "8.44.0",
+                "@typescript-eslint/type-utils": "8.44.0",
+                "@typescript-eslint/utils": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^7.0.0",
                 "natural-compare": "^1.4.0",
@@ -1969,9 +1969,9 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.35.0",
+                "@typescript-eslint/parser": "^8.44.0",
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -1985,16 +1985,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.0.tgz",
-            "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.0.tgz",
+            "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.35.0",
-                "@typescript-eslint/types": "8.35.0",
-                "@typescript-eslint/typescript-estree": "8.35.0",
-                "@typescript-eslint/visitor-keys": "8.35.0",
+                "@typescript-eslint/scope-manager": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/typescript-estree": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -2006,18 +2006,18 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.0.tgz",
-            "integrity": "sha512-41xatqRwWZuhUMF/aZm2fcUsOFKNcG28xqRSS6ZVr9BVJtGExosLAm5A1OxTjRMagx8nJqva+P5zNIGt8RIgbQ==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.0.tgz",
+            "integrity": "sha512-ZeaGNraRsq10GuEohKTo4295Z/SuGcSq2LzfGlqiuEvfArzo/VRrT0ZaJsVPuKZ55lVbNk8U6FcL+ZMH8CoyVA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.35.0",
-                "@typescript-eslint/types": "^8.35.0",
+                "@typescript-eslint/tsconfig-utils": "^8.44.0",
+                "@typescript-eslint/types": "^8.44.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -2028,18 +2028,18 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.0.tgz",
-            "integrity": "sha512-+AgL5+mcoLxl1vGjwNfiWq5fLDZM1TmTPYs2UkyHfFhgERxBbqHlNjRzhThJqz+ktBqTChRYY6zwbMwy0591AA==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz",
+            "integrity": "sha512-87Jv3E+al8wpD+rIdVJm/ItDBe/Im09zXIjFoipOjr5gHUhJmTzfFLuTJ/nPTMc2Srsroy4IBXwcTCHyRR7KzA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.35.0",
-                "@typescript-eslint/visitor-keys": "8.35.0"
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2050,9 +2050,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.0.tgz",
-            "integrity": "sha512-04k/7247kZzFraweuEirmvUj+W3bJLI9fX6fbo1Qm2YykuBvEhRTPl8tcxlYO8kZZW+HIXfkZNoasVb8EV4jpA==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz",
+            "integrity": "sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2063,18 +2063,19 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.35.0.tgz",
-            "integrity": "sha512-ceNNttjfmSEoM9PW87bWLDEIaLAyR+E6BoYJQ5PfaDau37UGca9Nyq3lBk8Bw2ad0AKvYabz6wxc7DMTO2jnNA==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.0.tgz",
+            "integrity": "sha512-9cwsoSxJ8Sak67Be/hD2RNt/fsqmWnNE1iHohG8lxqLSNY8xNfyY7wloo5zpW3Nu9hxVgURevqfcH6vvKCt6yg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.35.0",
-                "@typescript-eslint/utils": "8.35.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/typescript-estree": "8.44.0",
+                "@typescript-eslint/utils": "8.44.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.1.0"
             },
@@ -2087,13 +2088,13 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.0.tgz",
-            "integrity": "sha512-0mYH3emanku0vHw2aRLNGqe7EXh9WHEhi7kZzscrMDf6IIRUQ5Jk4wp1QrledE/36KtdZrVfKnE32eZCf/vaVQ==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.0.tgz",
+            "integrity": "sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2105,16 +2106,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.0.tgz",
-            "integrity": "sha512-F+BhnaBemgu1Qf8oHrxyw14wq6vbL8xwWKKMwTMwYIRmFFY/1n/9T/jpbobZL8vp7QyEUcC6xGrnAO4ua8Kp7w==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz",
+            "integrity": "sha512-lqNj6SgnGcQZwL4/SBJ3xdPEfcBuhCG8zdcwCPgYcmiPLgokiNDKlbPzCwEwu7m279J/lBYWtDYL+87OEfn8Jw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.35.0",
-                "@typescript-eslint/tsconfig-utils": "8.35.0",
-                "@typescript-eslint/types": "8.35.0",
-                "@typescript-eslint/visitor-keys": "8.35.0",
+                "@typescript-eslint/project-service": "8.44.0",
+                "@typescript-eslint/tsconfig-utils": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/visitor-keys": "8.44.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -2130,20 +2131,20 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.0.tgz",
-            "integrity": "sha512-nqoMu7WWM7ki5tPgLVsmPM8CkqtoPUG6xXGeefM5t4x3XumOEKMoUZPdi+7F+/EotukN4R9OWdmDxN80fqoZeg==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.0.tgz",
+            "integrity": "sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.7.0",
-                "@typescript-eslint/scope-manager": "8.35.0",
-                "@typescript-eslint/types": "8.35.0",
-                "@typescript-eslint/typescript-estree": "8.35.0"
+                "@typescript-eslint/scope-manager": "8.44.0",
+                "@typescript-eslint/types": "8.44.0",
+                "@typescript-eslint/typescript-estree": "8.44.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2154,17 +2155,17 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.0.tgz",
-            "integrity": "sha512-zTh2+1Y8ZpmeQaQVIc/ZZxsx8UzgKJyNg1PTvjzC7WMhPSVS8bfDX34k1SrwOf016qd5RU3az2UxUNue3IfQ5g==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz",
+            "integrity": "sha512-zaz9u8EJ4GBmnehlrpoKvj/E3dNbuQ7q0ucyZImm3cLqJ8INTc970B1qEqDX/Rzq65r3TvVTN7kHWPBoyW7DWw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.35.0",
+                "@typescript-eslint/types": "8.44.0",
                 "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
@@ -5605,9 +5606,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+            "version": "5.9.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+            "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
             "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
@@ -5619,15 +5620,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.35.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.35.0.tgz",
-            "integrity": "sha512-uEnz70b7kBz6eg/j0Czy6K5NivaYopgxRjsnAJ2Fx5oTLo3wefTHIbL7AkQr1+7tJCRVpTs/wiM8JR/11Loq9A==",
+            "version": "8.44.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.44.0.tgz",
+            "integrity": "sha512-ib7mCkYuIzYonCq9XWF5XNw+fkj2zg629PSa9KNIQ47RXFF763S5BIX4wqz1+FLPogTZoiw8KmCiRPRa8bL3qw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.35.0",
-                "@typescript-eslint/parser": "8.35.0",
-                "@typescript-eslint/utils": "8.35.0"
+                "@typescript-eslint/eslint-plugin": "8.44.0",
+                "@typescript-eslint/parser": "8.44.0",
+                "@typescript-eslint/typescript-estree": "8.44.0",
+                "@typescript-eslint/utils": "8.44.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5638,7 +5640,7 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/ufo": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "prettier": "^3.2.5",
         "sass": "^1.55.0",
         "tailwindcss": "^3.4.6",
-        "typescript": "^5.8.3",
+        "typescript": "^5.9.2",
         "undici": "^7.10.0",
         "undici-types": "^7.10.0",
         "unplugin-vue-components": "^0.27.3",

--- a/src/refactoring/modules/documents/components/DocumentsInterface.vue
+++ b/src/refactoring/modules/documents/components/DocumentsInterface.vue
@@ -25,7 +25,7 @@
                     <template #item="{ item }">
                         <span
                             v-if="item.command"
-                            @click="item.command"
+                            @click="() => item.command()"
                             class="breadcrumb-item clickable"
                         >
                             {{ item.label }}
@@ -348,15 +348,15 @@ const downloadDocument = (document: IDocument) => {
         const downloadUrl = url.startsWith('http') ? url : `${BASE_URL}${url}`
 
         // Создаем временную ссылку для скачивания
-        const link = document.createElement('a')
+        const link = window.document.createElement('a')
         link.href = downloadUrl
         link.download = document.name || 'download'
         link.target = '_blank'
 
         // Добавляем в DOM, кликаем и удаляем
-        document.body.appendChild(link)
+        window.document.body.appendChild(link)
         link.click()
-        document.body.removeChild(link)
+        window.document.body.removeChild(link)
 
         // Показываем уведомление об успехе
         useFeedbackStore().showToast({
@@ -397,7 +397,7 @@ const viewDocument = (document: IDocument) => {
         // Проверяем, удалось ли открыть окно (может быть заблокировано блокировщиком попапов)
         if (!newWindow || newWindow.closed || typeof newWindow.closed === 'undefined') {
             useFeedbackStore().showToast({
-                type: 'warning',
+                type: 'warn',
                 title: 'Внимание',
                 message:
                     'Возможно, браузер заблокировал открытие новой вкладки. Попробуйте скачать документ.',
@@ -499,12 +499,12 @@ const copyFolderLink = (folder: IDocumentFolder) => {
                 })
             })
             .catch(() => {
-                const textArea = document.createElement('textarea')
+                const textArea = window.document.createElement('textarea')
                 textArea.value = fullUrl
-                document.body.appendChild(textArea)
+                window.document.body.appendChild(textArea)
                 textArea.select()
-                document.execCommand('copy')
-                document.body.removeChild(textArea)
+                window.document.execCommand('copy')
+                window.document.body.removeChild(textArea)
 
                 useFeedbackStore().showToast({
                     type: 'success',

--- a/src/refactoring/modules/documents/stores/documentsStore.ts
+++ b/src/refactoring/modules/documents/stores/documentsStore.ts
@@ -25,7 +25,7 @@ export const useDocumentsStore = defineStore('documentsStore', {
     breadcrumbs: [{ name: 'Документы', path: '/', id: null }],
     isLoading: false,
     selectedItems: new Set(),
-    _urlUpdateTimeout: null as NodeJS.Timeout | null
+    _urlUpdateTimeout: null as ReturnType<typeof setTimeout> | null
   }),
 
   getters: {

--- a/src/refactoring/modules/documents/types/IDocument.ts
+++ b/src/refactoring/modules/documents/types/IDocument.ts
@@ -59,7 +59,7 @@ export interface IDocumentsStoreState {
   breadcrumbs: Array<{ name: string; path: string; id: string | null }>
   isLoading: boolean
   selectedItems: Set<number>
-  _urlUpdateTimeout: NodeJS.Timeout | null
+  _urlUpdateTimeout: ReturnType<typeof setTimeout> | null
 }
 
 export interface ICreateDocumentPayload {


### PR DESCRIPTION
Fixes multiple TypeScript errors by correcting event handler types, explicitly referencing the global `window.document` object, aligning toast types, and using browser-compatible timer types.

This PR addresses several TypeScript compilation errors:
1.  **Event handler type mismatch:** Changed `@click="item.command"` to `@click="() => item.command()"` to correctly invoke the command function without passing an unexpected `MouseEvent` parameter.
2.  **Shadowed `document` object:** Replaced `document.createElement`, `document.body`, and `document.execCommand` with `window.document` equivalents to resolve conflicts with a local `document: IDocument` parameter.
3.  **Incorrect toast type:** Updated `type: 'warning'` to `type: 'warn'` to match the `IToastType` definition.
4.  **Node.js specific timer type:** Replaced `NodeJS.Timeout` with `ReturnType<typeof setTimeout>` for browser compatibility in timer variable declarations.
5.  **Dependency updates:** Updated `typescript` and `@typescript-eslint` packages to their latest compatible versions.

---
<a href="https://cursor.com/background-agent?bcId=bc-3bbadf26-fc7a-4d5b-984a-2fa483a9650c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3bbadf26-fc7a-4d5b-984a-2fa483a9650c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

