### PR TITLE
Fix missing tailwind css class in edit document dialog

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,19 @@ export default {
         extend: {
             colors: {
                 linkHover: '#34d399',
+                red: {
+                    50: '#fef2f2',
+                    100: '#fee2e2',
+                    200: '#fecaca',
+                    300: '#fca5a5',
+                    400: '#f87171',
+                    500: '#ef4444',
+                    600: '#dc2626',
+                    700: '#b91c1c',
+                    800: '#991b1b',
+                    900: '#7f1d1d',
+                    950: '#450a0a',
+                },
             },
             gridTemplateColumns: {
                 'auto-fill-230': 'repeat(auto-fill, minmax(230px, 1fr))',


### PR DESCRIPTION
Add missing default red color palette to `tailwind.config.js` to resolve PostCSS errors for undefined red utility classes.

---
<a href="https://cursor.com/background-agent?bcId=bc-45f5e92d-bda2-4503-8d13-00d19e75cf42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-45f5e92d-bda2-4503-8d13-00d19e75cf42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

