### PR TITLE
Fix missing css class and use existing colors

### DIFF
--- a/src/refactoring/modules/documents/components/EditDocumentDialog.vue
+++ b/src/refactoring/modules/documents/components/EditDocumentDialog.vue
@@ -574,7 +574,7 @@ watch(
 }
 
 .danger-zone {
-    @apply p-4 border border-red-200 dark:border-red-800 rounded-lg bg-red-50 dark:bg-red-900/20;
+    @apply p-4 border border-red-500 dark:border-red-800 rounded-lg bg-red-50 dark:bg-red-900/20;
 }
 
 .danger-zone h5 {


### PR DESCRIPTION
Replace non-existent `border-red-200` with `border-red-500` to resolve a PostCSS error and use an existing color class.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6345062-548c-4ab3-83f4-e395125aa4b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6345062-548c-4ab3-83f4-e395125aa4b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

