### PR TITLE
Stretch versions table to full width

### DIFF
--- a/src/refactoring/modules/documents/components/EditDocumentDialog.vue
+++ b/src/refactoring/modules/documents/components/EditDocumentDialog.vue
@@ -475,11 +475,11 @@ const formatDate = (dateString: string): string => {
 }
 
 .version-header {
-    @apply grid grid-cols-[80px_80px_140px_100px] gap-4 p-3 bg-surface-100 dark:bg-surface-800 border-b border-surface-200 dark:border-surface-700 text-sm font-medium text-surface-700 dark:text-surface-200;
+    @apply grid grid-cols-[auto_auto_1fr_auto] gap-4 p-3 bg-surface-100 dark:bg-surface-800 border-b border-surface-200 dark:border-surface-700 text-sm font-medium text-surface-700 dark:text-surface-200 w-full;
 }
 
 .version-row {
-    @apply grid grid-cols-[80px_80px_140px_100px] gap-4 p-3 border-b border-surface-200 dark:border-surface-700 hover:bg-surface-50 dark:hover:bg-surface-800 text-sm;
+    @apply grid grid-cols-[auto_auto_1fr_auto] gap-4 p-3 border-b border-surface-200 dark:border-surface-700 hover:bg-surface-50 dark:hover:bg-surface-800 text-sm w-full;
 }
 
 .version-row:last-child {
@@ -517,7 +517,7 @@ const formatDate = (dateString: string): string => {
 @media (max-width: 768px) {
     .version-header,
     .version-row {
-        @apply grid-cols-[60px_1fr_80px] gap-2;
+        @apply grid-cols-[auto_1fr_auto] gap-2;
     }
 
     .version-size {


### PR DESCRIPTION
Stretch the versions-table data to full width by updating its grid layout and adding `w-full`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e45bf2fa-c68f-4547-aac9-52dcdc781578">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e45bf2fa-c68f-4547-aac9-52dcdc781578">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

