### PR TITLE
Fix back button navigation to parent directory

### DIFF
--- a/src/refactoring/modules/documents/stores/documentsStore.ts
+++ b/src/refactoring/modules/documents/stores/documentsStore.ts
@@ -801,7 +801,7 @@ export const useDocumentsStore = defineStore('documentsStore', {
 
         arrayToPath(pathArray: string[]): string {
             if (!pathArray || pathArray.length === 0) return '/'
-            return pathArray.join('/')
+            return '/' + pathArray.join('/')
         },
 
         getUrlFromCurrentState(): string {


### PR DESCRIPTION
Add leading slash to `arrayToPath` to fix "Back" button navigation to parent directory.

The `arrayToPath` method was incorrectly returning paths without a leading slash, causing the "Back" button to navigate to the root directory instead of one level up. Adding the leading slash ensures correct path formation and proper navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7595190-2189-42b4-b332-0f11ea8152dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7595190-2189-42b4-b332-0f11ea8152dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

