### PR TITLE
Fix documents module type errors and empty page

### DIFF
--- a/src/refactoring/modules/documents/composables/useDocumentNavigation.ts
+++ b/src/refactoring/modules/documents/composables/useDocumentNavigation.ts
@@ -14,7 +14,7 @@ import { useFeedbackStore } from '@/refactoring/modules/feedback/stores/feedback
 import { ERouteNames } from '@/router/ERouteNames'
 import { pathToArray } from '@/refactoring/modules/documents/utils/pathUtils'
 import type { IDocumentFolder } from '@/refactoring/modules/documents/types/IDocument'
-import type { IBreadcrumb } from '@/refactoring/modules/documents/services/NavigationService'
+import { NavigationService, type IBreadcrumb } from '@/refactoring/modules/documents/services/NavigationService'
 
 export function useDocumentNavigation(documentSort?: any) {
     const router = useRouter()

--- a/src/refactoring/modules/documents/services/DocumentsApiService.ts
+++ b/src/refactoring/modules/documents/services/DocumentsApiService.ts
@@ -34,7 +34,15 @@ export class DocumentsApiService {
      */
     async fetchDocumentTypes(): Promise<IDocumentType[]> {
         const response = await axios.get<IDocumentTypesResponse>(`${BASE_URL}/api/documents/type/`)
-        return response.data?.results || response.data || []
+        // Handle both paginated response format and direct array format
+        if (response.data?.results) {
+            return response.data.results
+        }
+        // If response.data is already an array, return it
+        if (Array.isArray(response.data)) {
+            return response.data
+        }
+        return []
     }
 
     /**
@@ -167,7 +175,15 @@ export class DocumentsApiService {
         const response = await axios.get<IDocumentVersionsResponse>(
             `${BASE_URL}/api/documents/document/${documentId}/versions/`
         )
-        return response.data?.results || response.data || []
+        // Handle both paginated response format and direct array format
+        if (response.data?.results) {
+            return response.data.results
+        }
+        // If response.data is already an array, return it
+        if (Array.isArray(response.data)) {
+            return response.data
+        }
+        return []
     }
 
     /**

--- a/src/refactoring/modules/documents/stores/documentsStore.ts
+++ b/src/refactoring/modules/documents/stores/documentsStore.ts
@@ -121,6 +121,27 @@ export const useDocumentsStore = defineStore('documentsStore', {
         },
 
         /**
+         * Преобразует API структуру папки в IDocumentFolder
+         */
+        _convertApiFolderToDocumentFolder(apiFolder: { folder_id: string; name: string; path: string }): IDocumentFolder {
+            return {
+                id: null,
+                folder_id: apiFolder.folder_id,
+                name: apiFolder.name,
+                description: '',
+                path: apiFolder.path,
+                virtual_path: null,
+                is_dir: true,
+                visibility: 'public',
+                created_at: null,
+                updated_at: null,
+                size: null,
+                extension: '',
+                items: []
+            } as IDocumentFolder
+        },
+
+        /**
          * Обновляет breadcrumbs на основе данных API
          */
         _updateBreadcrumbs(data: IListDocumentsResponse): void {
@@ -130,9 +151,12 @@ export const useDocumentsStore = defineStore('documentsStore', {
             }
 
             if (data.current_folder && data.parent_folders) {
+                const currentFolder = this._convertApiFolderToDocumentFolder(data.current_folder)
+                const parentFolders = data.parent_folders.map(folder => this._convertApiFolderToDocumentFolder(folder))
+                
                 this.breadcrumbs = this._navigationService.updateFolderChainFromApi(
-                    data.current_folder,
-                    data.parent_folders || [],
+                    currentFolder,
+                    parentFolders,
                 )
             } else {
                 // Обрабатываем virtual_path или name с учетом path_parent (массив или строка)

--- a/src/refactoring/modules/documents/types/ApiTypes.ts
+++ b/src/refactoring/modules/documents/types/ApiTypes.ts
@@ -33,13 +33,13 @@ export interface ICreateDocumentRequest {
     number: string
     folder_path: string
     file: File
-    visibility: 'public' | 'private' | 'department'
+    visibility: 'creator' | 'public' | 'private' | 'department'
 }
 
 export interface ICreateFolderRequest {
     name: string
     path: string
-    visibility: 'public' | 'private' | 'department'
+    visibility: 'creator' | 'public' | 'private' | 'department'
 }
 
 export interface IAddVersionRequest {
@@ -143,6 +143,7 @@ export enum SortOrder {
 }
 
 export enum DocumentVisibility {
+    CREATOR = 'creator',
     PUBLIC = 'public',
     PRIVATE = 'private',
     DEPARTMENT = 'department'

--- a/src/refactoring/modules/documents/types/IDocument.ts
+++ b/src/refactoring/modules/documents/types/IDocument.ts
@@ -120,10 +120,10 @@ export interface IDocumentDetailsResponse {
     is_dir?: false
     size: number | null
     extension?: string
-    type_name: string
-    status: string
+    type_name?: string
+    status?: string
     approved_at?: string
-    versions: IDocumentVersion[]
+    versions?: IDocumentVersion[]
     file_url?: string
     download_url?: string
 }


### PR DESCRIPTION
Fix TypeScript errors and improve API response type handling within the documents module.

This PR addresses several type-related issues, including correct import of `NavigationService`, handling of paginated and direct array API responses for document types and versions, expanding `visibility` options to include 'creator', ensuring proper conversion of API folder structures to `IDocumentFolder`, and making optional fields in `IDocumentDetailsResponse` explicit.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b64fd41-9f72-4317-9ab9-e4bb3e7b8144">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8b64fd41-9f72-4317-9ab9-e4bb3e7b8144">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

