### PR TITLE
Investigate duplicate document list requests

### DIFF
--- a/src/refactoring/modules/documents/components/DocumentsInterface.vue
+++ b/src/refactoring/modules/documents/components/DocumentsInterface.vue
@@ -472,11 +472,18 @@ const initializeFromUrl = async () => {
 watch(
     () => props.path,
     async (newPath, oldPath) => {
+        // Предотвращаем обработку если уже идет навигация
+        if (documentsStore.isNavigating) {
+            return
+        }
+
         try {
             const targetPath = newPath && newPath.length > 0 ? arrayToPath(newPath) : '/'
 
-            if (targetPath !== documentsStore.currentPath) {
-                await documentNavigation.navigateToPath(targetPath)
+            // Проверяем, что путь действительно изменился и не совпадает с текущим
+            if (targetPath !== documentsStore.currentPath && !documentsStore.isNavigating) {
+                // Навигация без обновления URL, так как URL уже изменен
+                await documentsStore.fetchDocuments({ path: targetPath })
             }
         } catch (error) {}
     },

--- a/src/refactoring/modules/documents/composables/useDocumentNavigation.ts
+++ b/src/refactoring/modules/documents/composables/useDocumentNavigation.ts
@@ -38,6 +38,7 @@ export function useDocumentNavigation(documentSort?: any) {
     const navigateToFolder = async (folder: IDocumentFolder): Promise<void> => {
         try {
             await documentsStore.navigateToFolder(folder)
+            // Обновляем URL только после успешной навигации
             updateUrl()
             // Сбрасываем сортировку при навигации
             if (documentSort?.resetSort) {

--- a/src/refactoring/modules/documents/services/NavigationService.ts
+++ b/src/refactoring/modules/documents/services/NavigationService.ts
@@ -172,7 +172,7 @@ export class NavigationService {
                             })
                     }
                 }
-            }, 10)
+            }, 50) // Увеличиваем задержку для предотвращения гонки условий
         } catch (error) {
             // Ignore navigation errors
         }

--- a/src/refactoring/modules/documents/stores/documentsStore.ts
+++ b/src/refactoring/modules/documents/stores/documentsStore.ts
@@ -43,6 +43,7 @@ export const useDocumentsStore = defineStore('documentsStore', {
         documentTypes: [],
         breadcrumbs: [{ name: 'Документы', path: '/', id: null }],
         isLoading: false,
+        isNavigating: false,
         selectedItems: new Set(),
         _urlUpdateTimeout: null as ReturnType<typeof setTimeout> | null,
         // Поля для поиска
@@ -171,9 +172,15 @@ export const useDocumentsStore = defineStore('documentsStore', {
         },
 
         async fetchDocuments(payload: IListDocumentsPayload = {}): Promise<void> {
+            // Предотвращаем дублирование запросов
+            if (this.isNavigating) {
+                return
+            }
+
             const requestPath = this._getRequestPath(payload)
 
             try {
+                this.isNavigating = true
                 const data = await this._apiService.fetchDocuments({
                     ...payload,
                     path: requestPath,
@@ -205,6 +212,8 @@ export const useDocumentsStore = defineStore('documentsStore', {
                     time: 5000,
                 })
                 throw error
+            } finally {
+                this.isNavigating = false
             }
         },
 

--- a/src/refactoring/modules/documents/types/IDocument.ts
+++ b/src/refactoring/modules/documents/types/IDocument.ts
@@ -71,6 +71,7 @@ export interface IDocumentsStoreState {
     documentTypes: IDocumentType[]
     breadcrumbs: Array<{ name: string; path: string; id: string | null }>
     isLoading: boolean
+    isNavigating: boolean
     selectedItems: Set<number>
     _urlUpdateTimeout: ReturnType<typeof setTimeout> | null
     // Поля для поиска


### PR DESCRIPTION
Fixes duplicate API requests when navigating folders in the documents module.

The previous logic caused a `watch` on `props.path` to trigger a second document fetch after the initial navigation and URL update, leading to redundant API calls. This is resolved by introducing an `isNavigating` flag to prevent concurrent requests and optimizing the `watch` to directly call `fetchDocuments` without re-triggering URL updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-df1c76cb-5767-4bd6-912f-6052425c6464">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df1c76cb-5767-4bd6-912f-6052425c6464">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

