### PR TITLE
Fix duplicate folder navigation requests

### DIFF
--- a/src/refactoring/modules/documents/components/DocumentsInterface.vue
+++ b/src/refactoring/modules/documents/components/DocumentsInterface.vue
@@ -479,13 +479,19 @@ watch(
 
         try {
             const targetPath = newPath && newPath.length > 0 ? arrayToPath(newPath) : '/'
+            const currentPath = documentsStore.currentPath
 
-            // Проверяем, что путь действительно изменился и не совпадает с текущим
-            if (targetPath !== documentsStore.currentPath && !documentsStore.isNavigating) {
-                // Навигация без обновления URL, так как URL уже изменен
-                await documentsStore.fetchDocuments({ path: targetPath })
+            // Проверяем, что путь действительно изменился
+            if (targetPath !== currentPath) {
+                // Дополнительная проверка - не вызываем фетч, если уже идет навигация
+                if (!documentsStore.isNavigating) {
+                    // Навигация без обновления URL, так как URL уже изменен
+                    await documentsStore.fetchDocuments({ path: targetPath })
+                }
             }
-        } catch (error) {}
+        } catch (error) {
+            // Игнорируем ошибки в watcher
+        }
     },
     { immediate: false, deep: true },
 )

--- a/src/refactoring/modules/documents/composables/useDocumentNavigation.ts
+++ b/src/refactoring/modules/documents/composables/useDocumentNavigation.ts
@@ -38,12 +38,12 @@ export function useDocumentNavigation(documentSort?: any) {
     const navigateToFolder = async (folder: IDocumentFolder): Promise<void> => {
         try {
             await documentsStore.navigateToFolder(folder)
-            // Обновляем URL только после успешной навигации
-            updateUrl()
             // Сбрасываем сортировку при навигации
             if (documentSort?.resetSort) {
                 documentSort.resetSort()
             }
+            // Обновляем URL только после успешной навигации
+            updateUrl()
         } catch (error) {}
     }
 
@@ -53,11 +53,12 @@ export function useDocumentNavigation(documentSort?: any) {
     const navigateToPath = async (path: string): Promise<void> => {
         try {
             await documentsStore.navigateToPath(path)
-            updateUrl()
             // Сбрасываем сортировку при навигации
             if (documentSort?.resetSort) {
                 documentSort.resetSort()
             }
+            // Обновляем URL только после успешной навигации
+            updateUrl()
         } catch (error) {}
     }
 
@@ -67,11 +68,12 @@ export function useDocumentNavigation(documentSort?: any) {
     const navigateToFolderId = async (folderId: string): Promise<void> => {
         try {
             await documentsStore.navigateToFolderId(folderId)
-            updateUrl()
             // Сбрасываем сортировку при навигации
             if (documentSort?.resetSort) {
                 documentSort.resetSort()
             }
+            // Обновляем URL только после успешной навигации
+            updateUrl()
         } catch (error) {}
     }
 
@@ -81,11 +83,12 @@ export function useDocumentNavigation(documentSort?: any) {
     const navigateUp = async (): Promise<void> => {
         try {
             await documentsStore.navigateUp()
-            updateUrl()
             // Сбрасываем сортировку при навигации
             if (documentSort?.resetSort) {
                 documentSort.resetSort()
             }
+            // Обновляем URL только после успешной навигации
+            updateUrl()
         } catch (error) {}
     }
 

--- a/src/refactoring/modules/documents/services/NavigationService.ts
+++ b/src/refactoring/modules/documents/services/NavigationService.ts
@@ -133,48 +133,52 @@ export class NavigationService {
             }
 
             this._urlUpdateTimeout = setTimeout(() => {
-                const currentPathArray = pathToArray(currentPath)
-                const currentPathMatch = currentRoute.params.pathMatch
+                try {
+                    const currentPathArray = pathToArray(currentPath)
+                    const currentPathMatch = currentRoute.params.pathMatch
 
-                let needsUpdate = false
+                    let needsUpdate = false
 
-                if (currentPathArray.length === 0) {
-                    needsUpdate =
-                        currentRoute.name !== ERouteNames.DOCUMENTS || !!currentPathMatch
-                } else {
-                    const expectedPathMatch = currentPathArray.join('/')
-                    const actualPathMatch = Array.isArray(currentPathMatch)
-                        ? currentPathMatch.join('/')
-                        : currentPathMatch || ''
-
-                    needsUpdate =
-                        currentRoute.name !== ERouteNames.DOCUMENTS_FOLDER ||
-                        actualPathMatch !== expectedPathMatch
-                }
-
-                if (needsUpdate) {
                     if (currentPathArray.length === 0) {
-                        router.replace({ name: ERouteNames.DOCUMENTS }).catch((error: any) => {
-                            if (error.name !== 'NavigationDuplicated') {
-                                console.error('Navigation error:', error)
-                            }
-                        })
+                        needsUpdate =
+                            currentRoute.name !== ERouteNames.DOCUMENTS || !!currentPathMatch
                     } else {
-                        router
-                            .replace({
-                                name: ERouteNames.DOCUMENTS_FOLDER,
-                                params: { pathMatch: currentPathArray },
-                            })
-                            .catch((error: any) => {
+                        const expectedPathMatch = currentPathArray.join('/')
+                        const actualPathMatch = Array.isArray(currentPathMatch)
+                            ? currentPathMatch.join('/')
+                            : currentPathMatch || ''
+
+                        needsUpdate =
+                            currentRoute.name !== ERouteNames.DOCUMENTS_FOLDER ||
+                            actualPathMatch !== expectedPathMatch
+                    }
+
+                    if (needsUpdate) {
+                        if (currentPathArray.length === 0) {
+                            router.replace({ name: ERouteNames.DOCUMENTS }).catch((error: any) => {
                                 if (error.name !== 'NavigationDuplicated') {
-                                    console.error('Navigation error:', error)
+                                    console.warn('Navigation warning:', error)
                                 }
                             })
+                        } else {
+                            router
+                                .replace({
+                                    name: ERouteNames.DOCUMENTS_FOLDER,
+                                    params: { pathMatch: currentPathArray },
+                                })
+                                .catch((error: any) => {
+                                    if (error.name !== 'NavigationDuplicated') {
+                                        console.warn('Navigation warning:', error)
+                                    }
+                                })
+                        }
                     }
+                } catch (innerError) {
+                    // Игнорируем ошибки обновления URL
                 }
-            }, 50) // Увеличиваем задержку для предотвращения гонки условий
+            }, 100) // Увеличиваем задержку для предотвращения гонки условий
         } catch (error) {
-            // Ignore navigation errors
+            // Игнорируем ошибки навигации
         }
     }
 

--- a/src/refactoring/modules/documents/stores/documentsStore.ts
+++ b/src/refactoring/modules/documents/stores/documentsStore.ts
@@ -28,6 +28,9 @@ import type {
 // Расширяем интерфейс состояния
 interface IExtendedDocumentsStoreState extends Omit<IDocumentsStoreState, 'breadcrumbs'> {
     breadcrumbs: IBreadcrumb[]
+    // Поля для предотвращения дублирования запросов
+    _lastRequestPath: string | null
+    _currentRequest: Promise<void> | null
     // Сервисы
     _navigationService: NavigationService
     _apiService: DocumentsApiService
@@ -50,6 +53,9 @@ export const useDocumentsStore = defineStore('documentsStore', {
         searchQuery: '',
         isSearchMode: false,
         searchTimeout: null as ReturnType<typeof setTimeout> | null,
+        // Поле для предотвращения дублирования запросов
+        _lastRequestPath: null as string | null,
+        _currentRequest: null as Promise<void> | null,
         // Сервисы
         _navigationService: new NavigationService(),
         _apiService: new DocumentsApiService(),
@@ -173,14 +179,42 @@ export const useDocumentsStore = defineStore('documentsStore', {
 
         async fetchDocuments(payload: IListDocumentsPayload = {}): Promise<void> {
             // Предотвращаем дублирование запросов
-            if (this.isNavigating) {
+            if (this.isNavigating || this._currentRequest) {
+                // Если уже идет запрос, ждем его завершения
+                if (this._currentRequest) {
+                    await this._currentRequest
+                }
                 return
             }
 
             const requestPath = this._getRequestPath(payload)
+            
+            // Дополнительная проверка - если запрашиваем тот же путь, что уже загружен
+            if (!payload.search && requestPath === this.currentPath && this.currentItems.length > 0) {
+                return
+            }
+            
+            // Проверяем, что не делаем тот же запрос, что и в прошлый раз
+            const requestKey = `${requestPath}|${payload.search || ''}|${payload.sort_by || ''}|${payload.sort_order || ''}`
+            if (requestKey === this._lastRequestPath) {
+                return
+            }
 
+            const requestPromise = this._executeRequest(payload, requestPath, requestKey)
+            this._currentRequest = requestPromise
+            
+            try {
+                await requestPromise
+            } finally {
+                this._currentRequest = null
+            }
+        },
+        
+        async _executeRequest(payload: IListDocumentsPayload, requestPath: string, requestKey: string): Promise<void> {
             try {
                 this.isNavigating = true
+                this._lastRequestPath = requestKey
+                
                 const data = await this._apiService.fetchDocuments({
                     ...payload,
                     path: requestPath,
@@ -276,8 +310,16 @@ export const useDocumentsStore = defineStore('documentsStore', {
         },
 
         async navigateToFolder(folder: IDocumentFolder): Promise<void> {
+            // Предотвращаем дублирование запросов
+            if (this.isNavigating) {
+                return
+            }
+            
             // При навигации к папке выходим из режима поиска
-            await this.clearSearch()
+            if (this.isSearchMode) {
+                this.isSearchMode = false
+                this.searchQuery = ''
+            }
 
             if (folder.folder_id) {
                 await this.fetchDocuments({ folder_id: folder.folder_id })
@@ -289,12 +331,28 @@ export const useDocumentsStore = defineStore('documentsStore', {
         },
 
         async navigateToFolderId(folderId: string): Promise<void> {
-            await this.clearSearch()
+            // Предотвращаем дублирование запросов
+            if (this.isNavigating) {
+                return
+            }
+            
+            if (this.isSearchMode) {
+                this.isSearchMode = false
+                this.searchQuery = ''
+            }
             await this.fetchDocuments({ folder_id: folderId })
         },
 
         async navigateToPath(path: string): Promise<void> {
-            await this.clearSearch()
+            // Предотвращаем дублирование запросов
+            if (this.isNavigating) {
+                return
+            }
+            
+            if (this.isSearchMode) {
+                this.isSearchMode = false
+                this.searchQuery = ''
+            }
             try {
                 await this.fetchDocuments({ path })
             } catch (error) {
@@ -309,8 +367,16 @@ export const useDocumentsStore = defineStore('documentsStore', {
             if (this.currentPath === '/' || !this.currentPath) {
                 return
             }
+            
+            // Предотвращаем дублирование запросов
+            if (this.isNavigating) {
+                return
+            }
 
-            await this.clearSearch()
+            if (this.isSearchMode) {
+                this.isSearchMode = false
+                this.searchQuery = ''
+            }
 
             const parentPath = getParentPath(this.currentPath)
             await this.fetchDocuments({ path: parentPath })
@@ -596,6 +662,10 @@ export const useDocumentsStore = defineStore('documentsStore', {
                 clearTimeout(this.searchTimeout)
                 this.searchTimeout = null
             }
+            
+            // Очищаем состояние запросов
+            this._lastRequestPath = null
+            this._currentRequest = null
 
             this._navigationService.cleanup()
         },


### PR DESCRIPTION
Fixes duplicate API requests in the documents module by implementing request deduplication and improving navigation state management.

The issue stemmed from multiple navigation layers, race conditions in watchers, redundant calls in navigation methods, and timing issues with URL updates, leading to unnecessary and duplicate `fetchDocuments` calls. This PR addresses these root causes to ensure only one request is sent per navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2943bd6-4fee-484c-af68-b04f19cf5741">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2943bd6-4fee-484c-af68-b04f19cf5741">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

