### PR TITLE
Update folder list on new folder creation

### DIFF
--- a/src/refactoring/modules/documents/composables/useDocumentSort.ts
+++ b/src/refactoring/modules/documents/composables/useDocumentSort.ts
@@ -51,19 +51,14 @@ export function useDocumentSort() {
         try {
             const payload: any = {}
 
-            if (documentsStore.currentFolderId) {
-                payload.folder_id = documentsStore.currentFolderId
-            } else {
-                payload.path = documentsStore.currentPath
-            }
-
             // Добавляем параметры сортировки, если они установлены
             if (currentSort.value.field) {
                 payload.sort_by = currentSort.value.field
                 payload.sort_order = currentSort.value.order
             }
 
-            await documentsStore.fetchDocuments(payload)
+            // Используем новый метод принудительного обновления
+            await documentsStore.forceRefreshDocuments(payload)
         } catch (error) {}
     }
 

--- a/src/refactoring/modules/documents/stores/documentsStore.ts
+++ b/src/refactoring/modules/documents/stores/documentsStore.ts
@@ -384,13 +384,54 @@ export const useDocumentsStore = defineStore('documentsStore', {
 
 
         /**
+         * Принудительно обновляет список документов, игнорируя кэш
+         */
+        async _forceRefreshDocuments(): Promise<void> {
+            // Сбрасываем кэш запросов для принудительного обновления
+            this._lastRequestPath = null
+            
+            const payload: IListDocumentsPayload = {}
+            
+            if (this.currentFolderId) {
+                payload.folder_id = this.currentFolderId
+            } else {
+                payload.path = this.currentPath
+            }
+            
+            await this.fetchDocuments(payload)
+        },
+
+        /**
+         * Принудительно обновляет список документов с параметрами сортировки, игнорируя кэш
+         */
+        async forceRefreshDocuments(payload: IListDocumentsPayload = {}): Promise<void> {
+            // Сбрасываем кэш запросов для принудительного обновления
+            this._lastRequestPath = null
+            
+            const refreshPayload: IListDocumentsPayload = {
+                ...payload
+            }
+            
+            if (!refreshPayload.folder_id && !refreshPayload.path) {
+                if (this.currentFolderId) {
+                    refreshPayload.folder_id = this.currentFolderId
+                } else {
+                    refreshPayload.path = this.currentPath
+                }
+            }
+            
+            await this.fetchDocuments(refreshPayload)
+        },
+
+        /**
          * Обновляет текущий вид (обычный или поисковый)
          */
         async _refreshCurrentView(): Promise<void> {
             if (this.isSearchMode && this.searchQuery) {
                 await this.searchDocuments(this.searchQuery)
             } else {
-                await this.fetchDocuments()
+                // Принудительно обновляем список, игнорируя кэш
+                await this._forceRefreshDocuments()
             }
         },
 


### PR DESCRIPTION
Force document list refresh after creating a new folder to bypass caching issues.

The existing `fetchDocuments` method had a caching check that prevented the list from updating when a new folder was created in the *same* current path. This PR introduces a `_forceRefreshDocuments` method to explicitly bypass this cache and ensure the list is always updated.

---
<a href="https://cursor.com/background-agent?bcId=bc-e47463fb-f243-43ff-bee3-d9b7d8a39710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e47463fb-f243-43ff-bee3-d9b7d8a39710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

