### PR TITLE
Open or create chat with user

### DIFF
--- a/src/refactoring/modules/chat/components/SlidingChat.vue
+++ b/src/refactoring/modules/chat/components/SlidingChat.vue
@@ -173,8 +173,8 @@ const emit = defineEmits<Emits>()
 
 // Инициализация композабла с общей логикой чата
 const chatLogic = useChatLogic({
+    userId: props.initialUserId,
     initialChatId: props.initialChatId,
-    initialUserId: props.initialUserId,
     messagesContainerSelector: '#sliding-chat-messages',
 })
 
@@ -318,22 +318,29 @@ watch(
                 let chatToOpen: any = null
 
                 if (newUserId) {
+                    console.log('SlidingChat: Trying to find/create chat with userId:', newUserId)
                     chatToOpen = await chatStore.findOrCreateDirectChat(newUserId)
+                    console.log('SlidingChat: Successfully found/created chat:', chatToOpen)
                 } else if (newChatId) {
+                    console.log('SlidingChat: Trying to find chat with chatId:', newChatId)
                     chatToOpen = chatStore.chats.find((c) => c.id === newChatId) || null
                     if (!chatToOpen) {
                         // Попытаемся инициализировать чаты, если они еще не загружены
                         await chatStore.initializeOnce()
                         chatToOpen = chatStore.chats.find((c) => c.id === newChatId) || null
                     }
+                    console.log('SlidingChat: Found chat with chatId:', chatToOpen)
                 }
 
                 if (chatToOpen) {
+                    console.log('SlidingChat: Opening chat:', chatToOpen)
                     await chatStore.openChat(chatToOpen)
                     if (isMobile.value) mobileView.value = 'chat'
+                } else {
+                    console.log('SlidingChat: No chat found to open')
                 }
             } catch (error) {
-                // Ошибка при принудительном открытии чата
+                console.error('SlidingChat: Error opening chat:', error)
             }
         }
     },

--- a/src/refactoring/modules/chat/composables/useChatLogic.ts
+++ b/src/refactoring/modules/chat/composables/useChatLogic.ts
@@ -13,11 +13,9 @@ import type {
 
 export interface ChatLogicOptions {
     /** ID пользователя для создания диалога при инициализации */
-    userId?: string
+    userId?: string | null
     /** ID чата для открытия при инициализации */
     initialChatId?: number | null
-    /** ID пользователя для создания диалога при инициализации */
-    initialUserId?: string | null
     /** Селектор контейнера сообщений для скролла */
     messagesContainerSelector?: string
     /** Колбэк при открытии чата */
@@ -207,10 +205,6 @@ export function useChatLogic(options: ChatLogicOptions = {}) {
                     console.log('useChatLogic: Trying to find/create chat with userId:', options.userId)
                     chatToOpen = await chatStore.findOrCreateDirectChat(options.userId)
                     console.log('useChatLogic: Successfully found/created chat with userId:', options.userId, chatToOpen)
-                } else if (options.initialUserId) {
-                    console.log('useChatLogic: Trying to find/create chat with initialUserId:', options.initialUserId)
-                    chatToOpen = await chatStore.findOrCreateDirectChat(options.initialUserId)
-                    console.log('useChatLogic: Successfully found/created chat with initialUserId:', options.initialUserId, chatToOpen)
                 } else if (options.initialChatId) {
                     // Ищем чат по ID в загруженном списке
                     console.log('useChatLogic: Trying to find chat with initialChatId:', options.initialChatId)
@@ -245,7 +239,7 @@ export function useChatLogic(options: ChatLogicOptions = {}) {
                         chatStore.currentChat = null
 
                         // Попытаемся открыть первый доступный чат ТОЛЬКО если не был передан конкретный пользователь
-                        if (!options.userId && !options.initialUserId && chatStore.chats.length > 0) {
+                        if (!options.userId && chatStore.chats.length > 0) {
                             try {
                                 const firstChat = chatStore.chats[0]
                                 await chatStore.openChat(firstChat)
@@ -256,7 +250,7 @@ export function useChatLogic(options: ChatLogicOptions = {}) {
                             }
                         }
                     }
-                } else if (!options.userId && !options.initialUserId && chatStore.chats.length > 0) {
+                } else if (!options.userId && chatStore.chats.length > 0) {
                     // Если нет конкретного чата для открытия, но есть чаты - открываем первый
                     // ТОЛЬКО если не был передан конкретный пользователь
                     try {
@@ -274,7 +268,7 @@ export function useChatLogic(options: ChatLogicOptions = {}) {
                 
                 // Если была ошибка при создании чата с конкретным пользователем, 
                 // НЕ откатываемся к localStorage чату
-                if (options.userId || options.initialUserId) {
+                if (options.userId) {
                     console.log('useChatLogic: Failed to create chat with specific user, not falling back to localStorage')
                     // Очищаем текущий чат, чтобы показать пустое состояние
                     chatStore.currentChat = null

--- a/src/refactoring/modules/chat/stores/chatStore.ts
+++ b/src/refactoring/modules/chat/stores/chatStore.ts
@@ -451,8 +451,12 @@ export const useChatStore = defineStore('chatStore', {
 
         // Находит или создает диалог с пользователем
         async findOrCreateDirectChat(userId: string): Promise<IChat> {
+            console.log('chatStore.findOrCreateDirectChat: Looking for chat with userId:', userId)
+            
             const currentUser = useCurrentUser()
             const currentUserId = currentUser.id.value
+
+            console.log('chatStore.findOrCreateDirectChat: Current user ID:', currentUserId)
 
             if (!currentUserId) {
                 throw new Error('Текущий пользователь не определен')
@@ -467,13 +471,27 @@ export const useChatStore = defineStore('chatStore', {
                 }
 
                 const memberIds = chat.members.map((m) => m.user_uuid || m.user)
-                return memberIds.includes(currentUserId) && memberIds.includes(userId)
+                const hasCurrentUser = memberIds.includes(currentUserId)
+                const hasTargetUser = memberIds.includes(userId)
+                
+                console.log('chatStore.findOrCreateDirectChat: Checking chat:', {
+                    chatId: chat.id,
+                    chatType: chat.type,
+                    memberIds,
+                    hasCurrentUser,
+                    hasTargetUser,
+                    match: hasCurrentUser && hasTargetUser
+                })
+                
+                return hasCurrentUser && hasTargetUser
             })
 
             if (existingDialog) {
+                console.log('chatStore.findOrCreateDirectChat: Found existing dialog:', existingDialog)
                 return existingDialog
             }
 
+            console.log('chatStore.findOrCreateDirectChat: Creating new dialog with userId:', userId)
             return await this.createDirectChat(userId)
         },
 

--- a/src/refactoring/utils/openChat.ts
+++ b/src/refactoring/utils/openChat.ts
@@ -27,7 +27,18 @@ export const openChat = async (userId?: string | null, chatId?: number | null, o
         // Открываем скользящий чат без перезагрузки страницы
         console.log('openChat: Opening sliding chat with chatId:', chatId, 'userId:', userId)
         const { openSlidingChat } = useSlidingChatGlobal()
-        openSlidingChat(chatId, userId)
+        
+        // Проверяем, что userId действительно передан
+        if (userId) {
+            console.log('openChat: Opening chat with userId:', userId)
+            openSlidingChat(null, userId)
+        } else if (chatId) {
+            console.log('openChat: Opening chat with chatId:', chatId)
+            openSlidingChat(chatId, null)
+        } else {
+            console.log('openChat: Opening chat without specific parameters')
+            openSlidingChat(null, null)
+        }
     }
 }
 

--- a/src/views/user/AdverseEvents/FormAdverseEvent.vue
+++ b/src/views/user/AdverseEvents/FormAdverseEvent.vue
@@ -2103,7 +2103,7 @@ onUnmounted(() => {
                             <!-- Режим редактирования/просмотра - показываем автора события -->
                             <div
                                 class="md:flex gap-2 text-sm text-surface-600 dark:text-surface-300 cursor-pointer"
-                                @click.prevent="currentAdverseEvent.created_by?.id && openChat(currentAdverseEvent.created_by.id)"
+                                @click.prevent="currentAdverseEvent.created_by?.id && (() => { console.log('FormAdverseEvent: Opening chat with created_by.id:', currentAdverseEvent.created_by.id); openChat(currentAdverseEvent.created_by.id); })()"
                             >
                             <span>Создатель НС - </span>
                             <span>{{ getFullName(currentAdverseEvent.created_by ?? {}) }}</span>
@@ -2117,8 +2117,8 @@ onUnmounted(() => {
                             <span class="cursor-default" title="Дата создания НС">{{  formatResponsibilityDate(currentAdverseEvent?.created_at) || 'Не удалось определить дату создания НС' }}</span>
                         </div>
                         <div
-                            class="md:flex items-center gap-2 ml-4 text-sm text-surface-600 dark:text-surface-300 cursor-pointer 2222"
-                            @click.prevent="currentAdverseEvent.coordinator?.id && openChat(currentAdverseEvent.coordinator.id)"
+                            class="md:flex items-center gap-2 ml-4 text-sm text-surface-600 dark:text-surface-300 cursor-pointer"
+                            @click.prevent="currentAdverseEvent.coordinator?.id && (() => { console.log('FormAdverseEvent: Opening chat with coordinator.id:', currentAdverseEvent.coordinator.id); openChat(currentAdverseEvent.coordinator.id); })()"
                         >
                             <!-- Координатор -->
                             <span>Координатор НС - </span>


### PR DESCRIPTION
Standardize chat initiation to consistently use `userId`, fixing the inability to open or create direct chats with specific users from `FormAdverseEvent.vue`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7917c6f-de61-449c-8d77-32487724098f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e7917c6f-de61-449c-8d77-32487724098f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

