### PR TITLE
Changes from background agent bc-e27f2b66-1ece-4ab0-ac02-bacc7e28fa90

### DIFF
--- a/src/refactoring/modules/chat/components/ChatCreateDialog.vue
+++ b/src/refactoring/modules/chat/components/ChatCreateDialog.vue
@@ -498,6 +498,8 @@ const selectAllEmployees = () => {
 
 const clearAllSelection = () => {
     selectedKeys.value = {}
+    // Вызываем onSelectionChange для синхронизации состояния
+    onSelectionChange({})
 }
 
 // Обработчики событий


### PR DESCRIPTION
Fix: The "Clear" button in the chat group creation modal now correctly clears both the employee tree selection and the displayed list of selected participants.

Previously, `clearAllSelection` only reset `selectedKeys.value`, which is bound to the tree component. An explicit call `onSelectionChange({})` was added to `clearAllSelection` to ensure `selectedUsers.value` is reliably synchronized and cleared, preventing selected users from remaining visible after clearing the tree.

---
<a href="https://cursor.com/background-agent?bcId=bc-e27f2b66-1ece-4ab0-ac02-bacc7e28fa90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e27f2b66-1ece-4ab0-ac02-bacc7e28fa90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

