### PR TITLE
Update frontend for document response changes

### DIFF
--- a/src/refactoring/modules/documents/components/DocumentsInterface.vue
+++ b/src/refactoring/modules/documents/components/DocumentsInterface.vue
@@ -311,6 +311,7 @@ import {
     formatFileSize,
     formatDate,
     getDocumentIcon,
+    getCreatorDisplayName,
 } from '@/refactoring/modules/documents/utils/documentUtils'
 import { pathToArray, arrayToPath } from '@/refactoring/modules/documents/utils/pathUtils'
 import type {

--- a/src/refactoring/modules/documents/types/ApiTypes.ts
+++ b/src/refactoring/modules/documents/types/ApiTypes.ts
@@ -50,7 +50,29 @@ export interface IAddVersionRequest {
 // === API Ответы ===
 
 export interface IListDocumentsResponse {
-    path: string
+    next: string | null
+    previous: string | null
+    results: {
+        id: number | null
+        path: string
+        virtual_path: string | null
+        is_dir: boolean
+        name: string
+        visibility: 'creator' | 'public' | 'private' | 'department'
+        created_at: string | null
+        extension: string
+        items: Array<IDocument | IDocumentFolder>
+        size: number | null
+        updated_at: string | null
+        created_by?: {
+            id: string
+            first_name: string
+            last_name: string
+            email?: string
+        } | null
+    }
+    // Поддерживаем старые поля для обратной совместимости
+    path?: string
     current_folder?: {
         folder_id: string
         name: string
@@ -64,7 +86,7 @@ export interface IListDocumentsResponse {
     virtual_path?: string
     name?: string
     path_parent?: string[] | string
-    items: Array<IDocument | IDocumentFolder>
+    items?: Array<IDocument | IDocumentFolder>
     total_count?: number
     page?: number
     page_size?: number

--- a/src/refactoring/modules/documents/types/IDocument.ts
+++ b/src/refactoring/modules/documents/types/IDocument.ts
@@ -20,6 +20,12 @@ export interface IDocumentFolder {
     size: null
     extension: ''
     items: (IDocumentFolder | IDocument)[]
+    created_by?: {
+        id: string
+        first_name: string
+        last_name: string
+        email?: string
+    } | null
 }
 
 export interface IDocument {
@@ -32,7 +38,12 @@ export interface IDocument {
     virtual_path: string
     is_dir?: false
     visibility: 'creator' | 'public' | 'private' | 'department'
-    created_by: string
+    created_by: string | {
+        id: string
+        first_name: string
+        last_name: string
+        email?: string
+    }
     created_at: string
     updated_at: string
     size: number | null
@@ -114,7 +125,12 @@ export interface IDocumentDetailsResponse {
     description?: string
     path?: string
     visibility: 'creator' | 'public' | 'private' | 'department'
-    created_by: string
+    created_by: string | {
+        id: string
+        first_name: string
+        last_name: string
+        email?: string
+    }
     created_at: string
     updated_at: string
     virtual_path: string

--- a/src/refactoring/modules/documents/utils/documentUtils.ts
+++ b/src/refactoring/modules/documents/utils/documentUtils.ts
@@ -173,3 +173,23 @@ export const getVisibilityLabel = (visibility?: string): string => {
     }
     return visibilityMap[visibility || ''] || visibility || '—'
 }
+
+/**
+ * Получает полное имя создателя документа
+ * @param createdBy - информация о создателе (строка или объект)
+ * @returns полное имя или ID
+ */
+export const getCreatorDisplayName = (createdBy: string | { id: string; first_name: string; last_name: string; email?: string } | undefined): string => {
+    if (!createdBy) return '—'
+    
+    if (typeof createdBy === 'string') {
+        return createdBy
+    }
+    
+    if (typeof createdBy === 'object') {
+        const fullName = `${createdBy.first_name} ${createdBy.last_name}`.trim()
+        return fullName || createdBy.id
+    }
+    
+    return '—'
+}


### PR DESCRIPTION
Adapt frontend to new document API response structure, supporting pagination and detailed `created_by` information.

The backend changed the document listing API response from a direct array of items to an object with pagination fields (`next`, `previous`, `results`) and nested items. Additionally, the `created_by` field now returns a full user object instead of just an ID. This PR updates the frontend types, store logic, and adds a utility function to handle these changes while maintaining backward compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-eade4a2d-37eb-44c4-a7b2-fefba0df9dff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eade4a2d-37eb-44c4-a7b2-fefba0df9dff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

