### PR TITLE
Update documents module for backend changes

### DIFF
--- a/src/refactoring/modules/documents/services/DocumentsApiService.ts
+++ b/src/refactoring/modules/documents/services/DocumentsApiService.ts
@@ -69,6 +69,8 @@ export class DocumentsApiService {
             `${BASE_URL}/api/documents/list/`, 
             requestPayload
         )
+        
+        // API теперь всегда возвращает структуру с пагинацией {next, previous, results}
         return response.data
     }
 

--- a/src/refactoring/modules/documents/stores/documentsStore.ts
+++ b/src/refactoring/modules/documents/stores/documentsStore.ts
@@ -117,7 +117,7 @@ export const useDocumentsStore = defineStore('documentsStore', {
         _processApiResponse(data: IListDocumentsResponse, payload: IListDocumentsPayload): void {
             if (!data || typeof data !== 'object') return
 
-            // Обрабатываем новую структуру ответа с results
+            // Бэкенд теперь всегда возвращает новую структуру ответа с пагинацией {next, previous, results}
             if (data.results) {
                 this.currentPath = data.results.path || this._getRequestPath(payload)
                 this.currentFolderId = payload.folder_id || this.currentFolderId
@@ -128,15 +128,10 @@ export const useDocumentsStore = defineStore('documentsStore', {
                     this._updateBreadcrumbsFromResults(data.results)
                 }
             } else {
-                // Обратная совместимость с старым форматом
-                this.currentPath = data.path || this._getRequestPath(payload)
-                this.currentFolderId = data.current_folder?.folder_id || payload.folder_id || this.currentFolderId
-                this.currentItems = data.items || []
-
-                // Обновляем breadcrumbs только если не в режиме поиска
-                if (!payload.search) {
-                    this._updateBreadcrumbs(data)
-                }
+                // Fallback на случай если структура ответа неожиданная
+                console.warn('Unexpected API response structure:', data)
+                this.currentPath = this._getRequestPath(payload)
+                this.currentItems = []
             }
         },
 
@@ -180,9 +175,12 @@ export const useDocumentsStore = defineStore('documentsStore', {
         },
 
         /**
-         * Обновляет breadcrumbs на основе данных API (старый формат)
+         * Обновляет breadcrumbs на основе данных API (старый формат) - DEPRECATED
+         * Оставлено для обратной совместимости, но больше не используется
          */
         _updateBreadcrumbs(data: IListDocumentsResponse): void {
+            console.warn('_updateBreadcrumbs is deprecated. API should use new paginated format.')
+            
             // Кешируем путь текущей папки по её virtual_path
             if (data.virtual_path && data.path) {
                 this._navigationService.cacheFolderPath(data.virtual_path, data.path)


### PR DESCRIPTION
Update the documents module to support the new paginated API response structure from the backend.

The backend now consistently returns document listings in a paginated format (`{next, previous, results}`). This PR updates the frontend logic to exclusively process this new structure, removing legacy handling for the old format and simplifying data extraction from `data.results`.

---
<a href="https://cursor.com/background-agent?bcId=bc-a823f4b3-8538-4b45-b6f0-3c2d168765a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a823f4b3-8538-4b45-b6f0-3c2d168765a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

