### PR TITLE
Fix chat employee selection and invitation bug

### DIFF
--- a/src/refactoring/modules/chat/components/EmployeeListItem.vue
+++ b/src/refactoring/modules/chat/components/EmployeeListItem.vue
@@ -15,8 +15,6 @@
                 </span>
             </div>
         </div>
-
-        <Button icon="pi pi-plus" size="small" severity="success" text rounded />
     </div>
 </template>
 

--- a/src/refactoring/modules/chat/components/InviteUsersDialog.vue
+++ b/src/refactoring/modules/chat/components/InviteUsersDialog.vue
@@ -568,8 +568,23 @@ function handleNodeLabelClick(node: any, event: MouseEvent) {
         return
     }
 
-    // Для листьев (сотрудников) клик по label не делает ничего
-    // Добавление происходит только через кнопку "+"
+    // Для листьев (сотрудников) клик по label переключает выбор
+    if (node?.isLeaf && node?.data) {
+        event.stopPropagation()
+        const isSelected = selectedKeys.value[node.key]
+        if (isSelected) {
+            // Снимаем выбор
+            const newSelectedKeys = { ...selectedKeys.value }
+            delete newSelectedKeys[node.key]
+            selectedKeys.value = newSelectedKeys
+        } else {
+            // Добавляем в выбор
+            selectedKeys.value = {
+                ...selectedKeys.value,
+                [node.key]: true,
+            }
+        }
+    }
 }
 
 // Обработчики раскрытия/сворачивания узлов


### PR DESCRIPTION
Remove redundant employee selection button and enable selection by clicking on employee names in the chat module to improve UX.

The user reported an unclear element next to employee names and an unintuitive selection process. This PR addresses these by removing the superfluous "+" button and making the employee name clickable for selection, aligning with the expected behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-cea24b36-8595-43d6-80c8-028499ad3533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cea24b36-8595-43d6-80c8-028499ad3533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

