### PR TITLE
Fix chat store invitation event syntax

### DIFF
--- a/src/refactoring/modules/chat/stores/chatStore.ts
+++ b/src/refactoring/modules/chat/stores/chatStore.ts
@@ -1024,7 +1024,7 @@ export const useChatStore = defineStore('chatStore', {
             } catch (error) {
                 console.error('[ChatStore] Ошибка диагностики WebSocket:', error)
             }
-        }
+        },
 
         // Симулирует WebSocket событие приглашения для тестирования
         simulateInvitationEvent(chatId?: number, userName?: string): void {


### PR DESCRIPTION
Add a comma after the `diagnoseWebSocketConnection` method to fix a syntax error in the Pinia store's `actions` object.

The `actions` object in a Pinia store requires all methods to be comma-separated, similar to properties in a JavaScript object. The missing comma after `diagnoseWebSocketConnection` caused the subsequent `simulateInvitationEvent` method to be parsed incorrectly, leading to a build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-262f6f1b-7acb-48fe-b28e-20421e4c7f1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-262f6f1b-7acb-48fe-b28e-20421e4c7f1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

