### PR TITLE
Fix chat invitation bugs

### DIFF
--- a/src/refactoring/modules/chat/components/InvitationListItem.vue
+++ b/src/refactoring/modules/chat/components/InvitationListItem.vue
@@ -11,7 +11,7 @@
             <div class="invitation-title">{{ invitation.chat.title }}</div>
             <div class="invitation-sub">
                 <span class="invitation-message">
-                    {{ invitation.created_by.first_name }} {{ invitation.created_by.last_name }} приглашает вас
+                    {{ stripHtmlTags(invitation.created_by.first_name) }} {{ stripHtmlTags(invitation.created_by.last_name) }} приглашает вас
                 </span>
             </div>
         </div>
@@ -60,6 +60,14 @@ const props = defineProps<Props>()
 defineEmits<Emits>()
 
 const isProcessing = ref(false)
+
+/**
+ * Очищает HTML теги из строки, оставляя только текст
+ */
+const stripHtmlTags = (str: string): string => {
+    if (!str) return str
+    return str.replace(/<[^>]*>/g, '')
+}
 
 // Получение инициалов для иконки
 const chatInitials = computed(() => {


### PR DESCRIPTION
Fixes chat invitation loading and display issues, and removes HTML tags from user names.

Previously, invitations could disappear on page refresh if `fetchInvitations` failed silently, and newly sent invitations from the management modal wouldn't appear immediately due to a lack of explicit refresh. Additionally, user names sometimes displayed raw HTML tags. This PR ensures invitation loading errors don't block chat initialization, explicitly refreshes invitations after creation, and strips HTML from displayed user names.

---
<a href="https://cursor.com/background-agent?bcId=bc-e124b504-065e-4793-a142-0ef03ff05947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e124b504-065e-4793-a142-0ef03ff05947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

