### PR TITLE
Remove mark tag from chat invitations

### DIFF
--- a/src/refactoring/modules/chat/components/ChatCreateDialog.vue
+++ b/src/refactoring/modules/chat/components/ChatCreateDialog.vue
@@ -768,11 +768,9 @@ const onNodeCollapse = (node: any) => {
     }
 }
 
-// Подсветка совпадений поиска
+// Возвращает исходный текст без подсветки
 const highlightMatch = (label: string = '', q: string = '') => {
-    if (!q) return label
-    const safe = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    return label.replace(new RegExp(`(${safe})`, 'ig'), '<mark>$1</mark>')
+    return label
 }
 
 // Строит объект expandedKeys на основе дерева
@@ -1103,13 +1101,6 @@ onUnmounted(() => {
     opacity: 1;
 }
 
-/* Подсветка совпадений поиска */
-:deep(mark) {
-    background-color: var(--yellow-200);
-    color: var(--text-color);
-    padding: 0;
-    border-radius: 2px;
-}
 
 
 /* Стили для секции выбора участников */
@@ -1241,10 +1232,6 @@ onUnmounted(() => {
     background: var(--surface-700);
 }
 
-:global(.dark) :deep(mark) {
-    background-color: var(--yellow-600);
-    color: var(--surface-0);
-}
 
 :global(.dark) .member-selection-section {
     background: var(--surface-800);

--- a/src/refactoring/modules/chat/components/InviteUsersDialog.vue
+++ b/src/refactoring/modules/chat/components/InviteUsersDialog.vue
@@ -651,12 +651,10 @@ const focusSearch = () => {
 }
 
 /**
- * Подсвечивает совпадения поискового запроса в тексте label.
+ * Возвращает исходный текст без подсветки.
  */
 const highlightMatch = (label: string = '', q: string = '') => {
-    if (!q) return label
-    const safe = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    return label.replace(new RegExp(`(${safe})`, 'ig'), '<mark>$1</mark>')
+    return label
 }
 
 /**
@@ -830,13 +828,6 @@ onUnmounted(() => {
     opacity: 1;
 }
 
-/* Подсветка совпадений поиска */
-:deep(mark) {
-    background-color: var(--yellow-200);
-    color: var(--text-color);
-    padding: 0;
-    border-radius: 2px;
-}
 
 /* Стили для выбранных участников */
 .selected-users {
@@ -895,8 +886,4 @@ onUnmounted(() => {
     background: var(--surface-700);
 }
 
-:global(.dark) :deep(mark) {
-    background-color: var(--yellow-600);
-    color: var(--surface-0);
-}
 </style>

--- a/src/refactoring/modules/documents/components/DocumentFiltersDialog.vue
+++ b/src/refactoring/modules/documents/components/DocumentFiltersDialog.vue
@@ -567,11 +567,9 @@ const closeDialog = () => {
     visible.value = false
 }
 
-// Подсветка совпадений поиска
+// Возвращает исходный текст без подсветки
 const highlightMatch = (label: string = '', q: string = '') => {
-    if (!q) return label
-    const safe = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    return label.replace(new RegExp(`(${safe})`, 'ig'), '<mark>$1</mark>')
+    return label
 }
 
 // Поиск создателей с дебаунсом
@@ -765,13 +763,6 @@ onUnmounted(() => {
     @apply text-sm font-medium;
 }
 
-/* Подсветка совпадений поиска */
-:deep(mark) {
-    background-color: var(--yellow-200);
-    color: var(--text-color);
-    padding: 0;
-    border-radius: 2px;
-}
 
 /* Стили для темной темы */
 :global(.dark) .employee-tree-container {
@@ -783,10 +774,6 @@ onUnmounted(() => {
     background: var(--surface-700);
 }
 
-:global(.dark) :deep(mark) {
-    background-color: var(--yellow-600);
-    color: var(--surface-0);
-}
 
 /* Утилитарные классы */
 .space-y-6 > * + * {


### PR DESCRIPTION
Remove `<mark>` tags and their associated CSS styles to disable text highlighting in chat invitations and other dialogs.

The user explicitly requested the removal of the `<mark>` tag highlighting, stating it was unnecessary and unwanted in chat invitations. This change ensures that names and other text in these components are displayed as plain text without any search-related highlighting.

---
<a href="https://cursor.com/background-agent?bcId=bc-6247b3b8-9292-4570-85d5-3fdddf05cad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6247b3b8-9292-4570-85d5-3fdddf05cad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

